### PR TITLE
Pin biopython to 1.77 for now

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -15,6 +15,7 @@ dependencies:
   - rdkit
   # Chimera reimplementation
   - biotite
+  - biopython 1.77
   # mmligner
   - mmligner
   # theseus


### PR DESCRIPTION
## Description

Pin biopython to 1.77 to workaround the `Bio.Alphabet` deprecation. The code in `opencadd.structure.superposition.sequences` will have to be updated at some point to remove this pin (it's not too complicated) but for now we'll just prevent 1.78 from being installed.

See https://github.com/volkamerlab/opencadd/pull/44#issuecomment-689367674 for more details.

