### PR TITLE
Pocket visualization

### DIFF
--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -142,7 +142,7 @@ class Pocket:
 
         Returns
         -------
-        pandas._dataFrame
+        pandas.DataFrame
             Residue ID and residue label (columns) for all pocket residues (rows).
         """
 
@@ -157,7 +157,7 @@ class Pocket:
 
         Returns
         -------
-        pandas._dataFrame
+        pandas.DataFrame
             Name, color and subpocket center (columns) for all subpockets (rows).
         """
 
@@ -181,7 +181,7 @@ class Pocket:
 
         Returns
         -------
-        pandas._dataFrame
+        pandas.DataFrame
             Name, color, involved residue IDs and labels (columns) for all regions.
         """
         if self._regions == []:
@@ -215,7 +215,7 @@ class Pocket:
 
         Returns
         -------
-        pandas._dataFrame
+        pandas.DataFrame
             Anchor residues (rows) with the following columns:
             - Subpocket name and color
             - Anchor residue IDs (user-defined input IDs or alternative
@@ -243,7 +243,7 @@ class Pocket:
             Pocket centroid (coordinates).
         """
 
-        dataframe = self._data
+        dataframe = self.data
 
         atoms = dataframe[
             (dataframe["residue.id"].isin(self._residue_ids)) & (dataframe["atom.name"] == "CA")
@@ -312,7 +312,7 @@ class Pocket:
         """
 
         subpocket = Subpocket.from_dataframe(
-            self._data, name, anchor_residue_ids, color, anchor_residue_labels
+            self.data, name, anchor_residue_ids, color, anchor_residue_labels
         )
         self._subpockets.append(subpocket)
 
@@ -333,7 +333,7 @@ class Pocket:
         """
 
         region = Region()
-        region.from_dataframe(self._data, name, residue_ids, color, residue_labels)
+        region.from_dataframe(self.data, name, residue_ids, color, residue_labels)
         self._regions.append(region)
 
     def visualize(self, show_pocket_centroid=True, show_anchor_residues=True):
@@ -416,7 +416,7 @@ class Pocket:
         """
 
         # Get all residue names
-        residue_id2ix = self._data[["residue.name", "residue.id"]].drop_duplicates()
+        residue_id2ix = self.data[["residue.name", "residue.id"]].drop_duplicates()
 
         if file_format == "mol2":
 

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -35,11 +35,10 @@ class Pocket:
     filepath
     name : str
         Name of protein.
-    _filepath : str or pathlib.Path
-        File path to structural protein data.
-    _data : pandas._dataFrame
-        Structural protein data with the following mandatory columns:
-        "residue.id", "atom.name", "atom.x", "atom.y", "atom.z".
+    _text : str
+        Structural protein data as string (file content).
+    _extension : str
+        Structural protein data format (file extension).
     _residue_ids : list of str
         Pocket residue IDs.
     _residue_labels : list of str
@@ -53,7 +52,8 @@ class Pocket:
     def __init__(self):
 
         self.name = None
-        self._filepath = None
+        self._text = None
+        self._extension = None
         self._residue_ids = None
         self._residue_labels = None
         self._subpockets = []

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -249,7 +249,12 @@ class Pocket:
             (dataframe["residue.id"].isin(self._residue_ids)) & (dataframe["atom.name"] == "CA")
         ]
 
-        _logger.info(f"The pocket centroid is calculated based on {len(atoms)} CA atoms.")
+        if len(atoms) != len(self._residue_ids):
+            _logger.info(
+                f"Missing pocket CA atoms. "
+                f"The pocket centroid is calculated based on {len(atoms)} CA atoms "
+                f"(total number of pocket residues is {len(self._residue_ids)})."
+            )
 
         centroid = atoms[["atom.x", "atom.y", "atom.z"]].mean().to_numpy()
 

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -353,18 +353,15 @@ class Pocket:
             Pocket visualization.
         """
 
-        filepath = str(self._filepath)
-
-        # Load structure from file in nglview  # TODO in the future: show_file > show_text?
-        view = nglview.show_file(filepath)
+        # Load structure from text in nglview
+        structure = nglview.adaptor.TextStructure(self._text, ext=self._extension)
+        view = nglview.widget.NGLWidget(structure)
         view._remote_call("setSize", target="Widget", args=["1000px", "600px"])
         view.clear()
 
-        # Get file format (this is important to know how nglview will index residues)
-        file_format = filepath.split(".")[-1]
-
         # Get residue ID > nglview index mapping
-        residue_id2ix = self._map_residue_id2ix(file_format)
+        # based on file format (this is important to know how nglview will index residues)
+        residue_id2ix = self._map_residue_id2ix(self._extension)
 
         # Show regions
         scheme_regions_list = []

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -5,6 +5,7 @@ Defines pockets.
 """
 
 import logging
+from pathlib import Path
 
 from matplotlib import colors
 import nglview
@@ -81,7 +82,45 @@ class Pocket:
             Pocket object.
         """
 
+        filepath = Path(filepath)
+        extension = filepath.suffix[1:]
+        with open(filepath, "r") as f:
+            text = f.read()
+        pocket = cls.from_text(text, extension, residue_ids, name, residue_labels)
+        return pocket
+
+    @classmethod
+    def from_text(cls, text, extension, residue_ids, name="", residue_labels=None):
+        """
+        Initialize Pocket object from structure protein file.
+
+        Attributes
+        ----------
+        text : str
+            Structural protein data as string (file content).
+        extension : str
+            Structural protein data format (file extension).
+        residue_ids : list of str
+            Pocket residue IDs.
+        name : str
+            Name of protein (default: empty string).
+        residue_labels : None or list of str
+            Pocket residue labels. Set to None by default.
+
+        Returns
+        -------
+        opencadd.structure.pocket.Pocket
+            Pocket object.
+        """
+
         pocket = cls()
+        pocket.name = name
+        pocket._text = text
+        pocket._extension = extension
+        pocket._residue_ids, pocket._residue_labels = _format_residue_ids_and_labels(
+            residue_ids, residue_labels
+        )
+        return pocket
 
     @property
     def data(self):

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -83,14 +83,18 @@ class Pocket:
 
         pocket = cls()
 
-        pocket.name = name
-        pocket._filepath = filepath
-        pocket._data = DataFrame.from_file(filepath)
-        residue_ids, residue_labels = _format_residue_ids_and_labels(residue_ids, residue_labels)
-        pocket._residue_ids = residue_ids
-        pocket._residue_labels = residue_labels
+    @property
+    def data(self):
+        """
+        Structural protein data.
 
-        return pocket
+        Returns
+        -------
+        pandas.DataFrame
+            Structural protein data with the following mandatory columns:
+            "residue.id", "atom.name", "atom.x", "atom.y", "atom.z".
+        """
+        return DataFrame.from_text(self._text, self._extension)
 
     @property
     def residues(self):

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -28,12 +28,12 @@ class Pocket:
 
     Attributes
     ----------
+    data
     residues
     subpockets
     regions
     anchor_residues
     centroid
-    filepath
     name : str
         Name of protein.
     _text : str
@@ -255,19 +255,6 @@ class Pocket:
 
         return centroid
 
-    @property
-    def filepath(self):
-        """
-        File path to structural protein data.
-
-        Returns
-        -------
-        pathlib.Path
-            File path to structural protein data.
-        """
-
-        return self._filepath
-
     def clear_subpockets(self):
         """
         Clear subpockets, i.e. remove all defined subpockets.
@@ -281,13 +268,6 @@ class Pocket:
         """
 
         self._regions = []
-
-    def delete_file(self):
-        """
-        Delete file with structural protein data.
-        """
-
-        self.filepath.unlink()
 
     def add_subpocket(
         self,
@@ -403,8 +383,8 @@ class Pocket:
 
         Parameters
         ----------
-        filepath : pathlib.Path or str
-            Path to structure file.
+        file_format : string
+            Structural protein data format.
 
         Returns
         -------

--- a/opencadd/structure/pocket/klifs.py
+++ b/opencadd/structure/pocket/klifs.py
@@ -17,7 +17,7 @@ class KlifsPocket(Pocket):
     """
 
     @classmethod
-    def from_structure_klifs_id(cls, structure_klifs_id, subpockets=None):
+    def from_structure_klifs_id(cls, structure_klifs_id, subpockets=None, extension="pdb"):
         """
         Get a KLIFS pocket (remotely by a structure KLIFS ID) that defines the KLIFS regions and
         subpockets.
@@ -35,6 +35,8 @@ class KlifsPocket(Pocket):
                 Subpocket name.
             "subpocket.color" : str
                 Subpocket color.
+        extension : str
+            Structure protein data file format. Defaults to PDB format.
 
         Returns
         -------
@@ -47,10 +49,13 @@ class KlifsPocket(Pocket):
 
         # Get pocket and coordinates for a structure (by a structure KLIFS ID)
         pocket = remote.pockets.by_structure_klifs_id(structure_klifs_id)
-        filepath = remote.coordinates.to_pdb(structure_klifs_id, ".", entity="complex")
+        text = remote.coordinates.to_text(
+            structure_klifs_id, entity="complex", extension=extension
+        )
 
-        pocket_3d = cls.from_file(
-            filepath,
+        pocket_3d = cls.from_text(
+            text,
+            extension,
             pocket["residue.id"].to_list(),
             "example kinase",
             pocket["residue.klifs_id"].to_list(),

--- a/opencadd/structure/pocket/subpocket.py
+++ b/opencadd/structure/pocket/subpocket.py
@@ -4,10 +4,14 @@ opencadd.structure.pocket.subpocket
 Defines subpockets.
 """
 
+import logging
+
 import numpy as np
 import pandas as pd
 
 from .utils import _format_residue_ids_and_labels
+
+_logger = logging.getLogger(__name__)
 
 
 class Subpocket:
@@ -224,6 +228,17 @@ class AnchorResidue:
                 anchor_residue.center = atoms[["atom.x", "atom.y", "atom.z"]].mean().to_numpy()
             else:
                 anchor_residue.center = None
+
+        if anchor_residue.id_alternative:
+            _logger.info(
+                f"Anchor residue {anchor_residue.id} is missing, "
+                f"use {anchor_residue.id_alternative} instead."
+            )
+        if anchor_residue.center is None:
+            _logger.info(
+                f"Anchor residue {anchor_residue.id} and its neighbors are missing "
+                f"- no anchor residue could be set."
+            )
 
         return anchor_residue
 


### PR DESCRIPTION
## Description

So far, in order to work with a structure in the `pocket` module, a local copy of its structure file was needed to satisfy the `Pocket` class method `visualize` (`nglview` visualization of structure/pocket). 

This was mainly the case because I could not make it work to show a structure from text in the mol2 format - but I figured it out now. Let's look at our options: 

```python
import nglview

# Show structure from file
view = nglview.show_file(filepath)

# Show structure from text (pdb format only!)
view = nglview.show_text(pdb_text)

# Show structure from text (any file format allowed by `nglview` - I tested only for pdb and mol2)
structure = nglview.adaptor.TextStructure(text, ext="mol2")
view = nglview.widget.NGLWidget(structure)
```

In this PR, the `pocket` module is updated in a way that `Pocket` class can be initialized from a file but also from text. 
This is helpful for the `KlifsPocket` subclass, where we fetch data via KLIFS IDs. Before, the file was downloaded and linked to the object via the `_filepath` attribute; now, we simply fetch the file text and format (`_text` and `_extension` attributes).

## Todos

  - [x] Remove class attribute `_filepath` but add `_text` and `_extension` (to indicate the text format)
  - [x] Change class attribute `_data` (structural data as DataFrame) into property `data`
  - [x] Split `Pocket.from_file` class method into
    - `Pocket.from_text` class method: Set all class attributes (new: `_text` and `_extension`)
    - `Pocket.from_file` class method: Get text from file and pass text to `Pocket.from_text`
  - [x] Update `KlifsPocket` according to changes in `Pocket` (fetch text from KLIFS - no need for file download any more, yay!!)
  - [x] Rerun pocket tutorial using the updated module
  - [x] Minor (admittedly unrelated) logging changes
    - [x] Pocket centroid caluclation: Log info if pocket CA atoms are missing.
    - [x] Anchor residues: Log info is anchor residues are missing

## Questions

None

## Status
- [x] Ready to go