### PR TITLE
Add Bioactivties.by_ligand_expo_id for remote module

### DIFF
--- a/docs/tutorials/databases_klifs.ipynb
+++ b/docs/tutorials/databases_klifs.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +529,7 @@
     "| __by_kinase_klifs_id__    | x | x | x | x | x |   | \n",
     "| __by_kinase_name__        | x | x | x |   |   |   |\n",
     "| __by_ligand_klifs_id__    |   | x | x | x | x |   |\n",
-    "| __by_ligand_expo_id__     |   | x | x |   |   |   |\n",
+    "| __by_ligand_expo_id__     |   | x | x | x |   |   |\n",
     "| __by_structure_klifs_id__ |   |   | x |   | x | x |\n",
     "| __by_structure_pdb_id__   |   |   | x |   |   |   |"
    ]
@@ -1896,7 +1896,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e266e779b2a646979a0a4f1d64540366",
+       "model_id": "e45b9560388648f1be349cc875cb56e5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2016,7 +2016,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a61c55ce0f104a6b80400258692bfd29",
+       "model_id": "a7a2708cce1440db9515da3a9504836a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2136,7 +2136,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df1a5eb67c5a4cac9279d352c3176403",
+       "model_id": "6d4e0c78a13b4e33bc9fb9170cc1b62a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2180,7 +2180,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d61912d8035e4b63bc8b164da6cb7010",
+       "model_id": "96085dfe2e50484c9112a48ba62819a7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2770,7 +2770,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da229eb8929b481caf8440730193864a",
+       "model_id": "7ecd173ce9344af1a3395a0a7ab2dc59",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2888,7 +2888,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a94c9f758a404b0fabc321ba746a9ef7",
+       "model_id": "ae4f49676ad04f02ac5baf0c9dcab743",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3044,7 +3044,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7bec809583444085b88d668cfe8fa94d",
+       "model_id": "1b52979cf0db4fdf80f3f0e26b3aca1b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3284,7 +3284,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb9f6150b9c9480b9c79b8b062cebf33",
+       "model_id": "200fa84bcab9401fa3df35d3c95759b7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3312,7 +3312,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6b7747a1afec4eafb1b952dc97362a51",
+       "model_id": "dcb1096e594e41c2a16e08abf3ff0e1c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3500,7 +3500,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "20c6f25af44f4393b07db7bba81618d6",
+       "model_id": "edd895aaf02e425a8af395c6a43cde37",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4080,28 +4080,76 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>6763</td>\n",
-       "      <td>3cqw</td>\n",
-       "      <td>A</td>\n",
+       "      <td>11746</td>\n",
+       "      <td>6s9x</td>\n",
+       "      <td>-</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>1</td>\n",
        "      <td>AKT1</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
+       "      <td>KLLGKGTFGKVILYAMKIL_________QNSRPFLTALKYSCFVME...</td>\n",
+       "      <td>L1W</td>\n",
+       "      <td>-</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>out</td>\n",
+       "      <td>na</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.959</td>\n",
+       "      <td>2.388</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>20.264299</td>\n",
+       "      <td>67.654297</td>\n",
+       "      <td>58.354900</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2534</td>\n",
+       "      <td>3ocb</td>\n",
+       "      <td>-</td>\n",
+       "      <td>B</td>\n",
+       "      <td>Human</td>\n",
+       "      <td>1</td>\n",
+       "      <td>AKT1</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...</td>\n",
-       "      <td>CQW</td>\n",
+       "      <td>XM1</td>\n",
        "      <td>-</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>in</td>\n",
        "      <td>in</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>2.7</td>\n",
        "      <td>8.0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.779</td>\n",
-       "      <td>2.093</td>\n",
+       "      <td>0.778</td>\n",
+       "      <td>2.095</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -4113,57 +4161,9 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>17.943501</td>\n",
-       "      <td>58.283501</td>\n",
-       "      <td>52.774200</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>10428</td>\n",
-       "      <td>6buu</td>\n",
-       "      <td>C</td>\n",
-       "      <td>B</td>\n",
-       "      <td>Human</td>\n",
-       "      <td>1</td>\n",
-       "      <td>AKT1</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...</td>\n",
-       "      <td>-</td>\n",
-       "      <td>-</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>in</td>\n",
-       "      <td>in</td>\n",
-       "      <td>2.4</td>\n",
-       "      <td>8.0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.776</td>\n",
-       "      <td>2.091</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>17.901100</td>\n",
-       "      <td>59.594799</td>\n",
-       "      <td>60.872501</td>\n",
+       "      <td>18.755400</td>\n",
+       "      <td>61.403500</td>\n",
+       "      <td>57.872101</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -4211,51 +4211,7 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11701</th>\n",
-       "      <td>9069</td>\n",
-       "      <td>6bq1</td>\n",
-       "      <td>-</td>\n",
-       "      <td>E</td>\n",
-       "      <td>Human</td>\n",
-       "      <td>1096</td>\n",
-       "      <td>PI4KA</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>_PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...</td>\n",
-       "      <td>E4S</td>\n",
-       "      <td>-</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>in</td>\n",
-       "      <td>in</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>6.8</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.699</td>\n",
-       "      <td>2.670</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>18.168600</td>\n",
-       "      <td>58.645401</td>\n",
-       "      <td>136.503006</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11702</th>\n",
+       "      <th>11708</th>\n",
        "      <td>9070</td>\n",
        "      <td>6bq1</td>\n",
        "      <td>-</td>\n",
@@ -4298,111 +4254,155 @@
        "      <td>131.186996</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11709</th>\n",
+       "      <td>9069</td>\n",
+       "      <td>6bq1</td>\n",
+       "      <td>-</td>\n",
+       "      <td>E</td>\n",
+       "      <td>Human</td>\n",
+       "      <td>1096</td>\n",
+       "      <td>PI4KA</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>_PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...</td>\n",
+       "      <td>E4S</td>\n",
+       "      <td>-</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>in</td>\n",
+       "      <td>in</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.8</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.699</td>\n",
+       "      <td>2.670</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>18.168600</td>\n",
+       "      <td>58.645401</td>\n",
+       "      <td>136.503006</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>11703 rows × 41 columns</p>\n",
+       "<p>11710 rows × 41 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "       structure.klifs_id structure.pdb_id structure.alternate_model  \\\n",
-       "0                    6763             3cqw                         A   \n",
-       "1                   10428             6buu                         C   \n",
+       "0                   11746             6s9x                         -   \n",
+       "1                    2534             3ocb                         -   \n",
        "...                   ...              ...                       ...   \n",
-       "11701                9069             6bq1                         -   \n",
-       "11702                9070             6bq1                         -   \n",
+       "11708                9070             6bq1                         -   \n",
+       "11709                9069             6bq1                         -   \n",
        "\n",
        "      structure.chain species.klifs  kinase.klifs_id kinase.klifs_name  \\\n",
        "0                   A         Human                1              AKT1   \n",
        "1                   B         Human                1              AKT1   \n",
        "...               ...           ...              ...               ...   \n",
-       "11701               E         Human             1096             PI4KA   \n",
-       "11702               A         Human             1096             PI4KA   \n",
+       "11708               A         Human             1096             PI4KA   \n",
+       "11709               E         Human             1096             PI4KA   \n",
        "\n",
        "      kinase.family kinase.group  \\\n",
        "0              <NA>         <NA>   \n",
        "1              <NA>         <NA>   \n",
        "...             ...          ...   \n",
-       "11701          <NA>         <NA>   \n",
-       "11702          <NA>         <NA>   \n",
+       "11708          <NA>         <NA>   \n",
+       "11709          <NA>         <NA>   \n",
        "\n",
        "                                        structure.pocket ligand.expo_id  \\\n",
-       "0      KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...            CQW   \n",
-       "1      KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...              -   \n",
+       "0      KLLGKGTFGKVILYAMKIL_________QNSRPFLTALKYSCFVME...            L1W   \n",
+       "1      KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...            XM1   \n",
        "...                                                  ...            ...   \n",
-       "11701  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
-       "11702  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
+       "11708  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
+       "11709  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
        "\n",
        "      ligand_allosteric.expo_id ligand.name ligand_allosteric.name  \\\n",
        "0                             -        <NA>                   <NA>   \n",
        "1                             -        <NA>                   <NA>   \n",
        "...                         ...         ...                    ...   \n",
-       "11701                         -        <NA>                   <NA>   \n",
-       "11702                         -        <NA>                   <NA>   \n",
+       "11708                         -        <NA>                   <NA>   \n",
+       "11709                         -        <NA>                   <NA>   \n",
        "\n",
        "      structure.dfg structure.ac_helix  structure.resolution  \\\n",
-       "0                in                 in                   2.0   \n",
-       "1                in                 in                   2.4   \n",
+       "0               out                 na                   2.6   \n",
+       "1                in                 in                   2.7   \n",
        "...             ...                ...                   ...   \n",
-       "11701            in                 in                   NaN   \n",
-       "11702            in                 in                   NaN   \n",
+       "11708            in                 in                   NaN   \n",
+       "11709            in                 in                   NaN   \n",
        "\n",
        "       structure.qualityscore  structure.missing_residues  \\\n",
-       "0                         8.0                           0   \n",
+       "0                         3.2                           9   \n",
        "1                         8.0                           0   \n",
        "...                       ...                         ...   \n",
-       "11701                     6.8                           2   \n",
-       "11702                     6.8                           2   \n",
+       "11708                     6.8                           2   \n",
+       "11709                     6.8                           2   \n",
        "\n",
        "       structure.missing_atoms  structure.rmsd1  structure.rmsd2  \\\n",
-       "0                            0            0.779            2.093   \n",
-       "1                            0            0.776            2.091   \n",
+       "0                            0            0.959            2.388   \n",
+       "1                            0            0.778            2.095   \n",
        "...                        ...              ...              ...   \n",
-       "11701                        0            1.699            2.670   \n",
-       "11702                        0            1.704            2.676   \n",
+       "11708                        0            1.704            2.676   \n",
+       "11709                        0            1.699            2.670   \n",
        "\n",
        "       structure.front  structure.gate  structure.back  structure.fp_i  \\\n",
-       "0                 True           False           False           False   \n",
-       "1                False           False           False           False   \n",
+       "0                False           False            True           False   \n",
+       "1                 True           False           False           False   \n",
        "...                ...             ...             ...             ...   \n",
-       "11701             True            True           False           False   \n",
-       "11702             True           False           False           False   \n",
+       "11708             True           False           False           False   \n",
+       "11709             True            True           False           False   \n",
        "\n",
        "       structure.fp_ii  structure.bp_i_a  structure.bp_i_b  \\\n",
        "0                False             False             False   \n",
-       "1                False             False             False   \n",
+       "1                 True             False             False   \n",
        "...                ...               ...               ...   \n",
-       "11701            False              True              True   \n",
-       "11702            False             False              True   \n",
+       "11708            False             False              True   \n",
+       "11709            False              True              True   \n",
        "\n",
        "       structure.bp_ii_in  structure.bp_ii_a_in  structure.bp_ii_b_in  \\\n",
        "0                   False                 False                 False   \n",
        "1                   False                 False                 False   \n",
        "...                   ...                   ...                   ...   \n",
-       "11701               False                 False                 False   \n",
-       "11702               False                 False                 False   \n",
+       "11708               False                 False                 False   \n",
+       "11709               False                 False                 False   \n",
        "\n",
        "       structure.bp_ii_out  structure.bp_ii_b  structure.bp_iii  \\\n",
-       "0                    False              False             False   \n",
+       "0                     True              False              True   \n",
        "1                    False              False             False   \n",
        "...                    ...                ...               ...   \n",
-       "11701                False              False             False   \n",
-       "11702                False              False             False   \n",
+       "11708                False              False             False   \n",
+       "11709                False              False             False   \n",
        "\n",
        "       structure.bp_iv  structure.bp_v  structure.grich_distance  \\\n",
-       "0                False           False                 17.943501   \n",
-       "1                False           False                 17.901100   \n",
+       "0                 True           False                 20.264299   \n",
+       "1                False           False                 18.755400   \n",
        "...                ...             ...                       ...   \n",
-       "11701            False           False                 18.168600   \n",
-       "11702            False           False                 18.324301   \n",
+       "11708            False           False                 18.324301   \n",
+       "11709            False           False                 18.168600   \n",
        "\n",
        "       structure.grich_angle  structure.grich_rotation structure.filepath  \n",
-       "0                  58.283501                 52.774200               <NA>  \n",
-       "1                  59.594799                 60.872501               <NA>  \n",
+       "0                  67.654297                 58.354900               <NA>  \n",
+       "1                  61.403500                 57.872101               <NA>  \n",
        "...                      ...                       ...                ...  \n",
-       "11701              58.645401                136.503006               <NA>  \n",
-       "11702              58.963501                131.186996               <NA>  \n",
+       "11708              58.963501                131.186996               <NA>  \n",
+       "11709              58.645401                136.503006               <NA>  \n",
        "\n",
-       "[11703 rows x 41 columns]"
+       "[11710 rows x 41 columns]"
       ]
      },
      "execution_count": 54,
@@ -5290,9 +5290,9 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>8733</td>\n",
+       "      <td>8735</td>\n",
        "      <td>5m5a</td>\n",
-       "      <td>B</td>\n",
+       "      <td>A</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>128</td>\n",
@@ -5334,9 +5334,9 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>8735</td>\n",
+       "      <td>8733</td>\n",
        "      <td>5m5a</td>\n",
-       "      <td>A</td>\n",
+       "      <td>B</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>128</td>\n",
@@ -5515,8 +5515,8 @@
       ],
       "text/plain": [
        "    structure.klifs_id structure.pdb_id structure.alternate_model  \\\n",
-       "0                 8733             5m5a                         B   \n",
-       "1                 8735             5m5a                         A   \n",
+       "0                 8735             5m5a                         A   \n",
+       "1                 8733             5m5a                         B   \n",
        "..                 ...              ...                       ...   \n",
        "12                3317             3eqf                         -   \n",
        "13                2991             1r0p                         -   \n",
@@ -7883,52 +7883,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>1061</td>\n",
-       "      <td>4wa9</td>\n",
-       "      <td>-</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Human</td>\n",
-       "      <td>392</td>\n",
-       "      <td>ABL1</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>HKLGGGQYGEVYEVAVK____________EIKPNLVQLLGV_IITE...</td>\n",
-       "      <td>AXI</td>\n",
-       "      <td>-</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>out</td>\n",
-       "      <td>na</td>\n",
-       "      <td>2.20</td>\n",
-       "      <td>5.6</td>\n",
-       "      <td>13</td>\n",
-       "      <td>4</td>\n",
-       "      <td>0.862</td>\n",
-       "      <td>2.189</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>13.955400</td>\n",
-       "      <td>47.188801</td>\n",
-       "      <td>49.136799</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>6755</td>\n",
-       "      <td>5hu9</td>\n",
+       "      <td>1047</td>\n",
+       "      <td>3qri</td>\n",
        "      <td>B</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
@@ -7937,18 +7893,62 @@
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
-       "      <td>66K</td>\n",
-       "      <td>66K</td>\n",
+       "      <td>919</td>\n",
+       "      <td>-</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>out</td>\n",
        "      <td>out</td>\n",
-       "      <td>1.53</td>\n",
-       "      <td>7.6</td>\n",
+       "      <td>2.10</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.918</td>\n",
-       "      <td>2.301</td>\n",
+       "      <td>0.928</td>\n",
+       "      <td>2.279</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>18.143700</td>\n",
+       "      <td>59.950401</td>\n",
+       "      <td>8.298940</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7526</td>\n",
+       "      <td>5mo4</td>\n",
+       "      <td>B</td>\n",
+       "      <td>A</td>\n",
+       "      <td>Human</td>\n",
+       "      <td>392</td>\n",
+       "      <td>ABL1</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIIIE...</td>\n",
+       "      <td>NIL</td>\n",
+       "      <td>AY7</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>out</td>\n",
+       "      <td>out</td>\n",
+       "      <td>2.17</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0.864</td>\n",
+       "      <td>2.218</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -7962,11 +7962,11 @@
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>True</td>\n",
-       "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>18.198700</td>\n",
-       "      <td>60.844898</td>\n",
-       "      <td>25.582899</td>\n",
+       "      <td>True</td>\n",
+       "      <td>19.025999</td>\n",
+       "      <td>63.105900</td>\n",
+       "      <td>16.033001</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -8015,52 +8015,52 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>203</th>\n",
-       "      <td>5716</td>\n",
-       "      <td>2qoh</td>\n",
+       "      <td>5702</td>\n",
+       "      <td>3mss</td>\n",
        "      <td>-</td>\n",
-       "      <td>B</td>\n",
+       "      <td>D</td>\n",
        "      <td>Mouse</td>\n",
        "      <td>532</td>\n",
        "      <td>ABL1</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
-       "      <td>P3Y</td>\n",
-       "      <td>-</td>\n",
+       "      <td>STI</td>\n",
+       "      <td>MS7</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>in</td>\n",
-       "      <td>in</td>\n",
+       "      <td>out</td>\n",
+       "      <td>out</td>\n",
        "      <td>1.95</td>\n",
-       "      <td>8.0</td>\n",
+       "      <td>7.6</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.779</td>\n",
-       "      <td>2.135</td>\n",
+       "      <td>0.921</td>\n",
+       "      <td>2.303</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>16.910601</td>\n",
-       "      <td>57.076801</td>\n",
-       "      <td>20.159500</td>\n",
+       "      <td>18.569700</td>\n",
+       "      <td>62.892899</td>\n",
+       "      <td>14.525800</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>204</th>\n",
-       "      <td>5711</td>\n",
-       "      <td>3oy3</td>\n",
+       "      <td>5709</td>\n",
+       "      <td>1opk</td>\n",
        "      <td>-</td>\n",
        "      <td>A</td>\n",
        "      <td>Mouse</td>\n",
@@ -8068,19 +8068,19 @@
        "      <td>ABL1</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIIIE...</td>\n",
-       "      <td>XY3</td>\n",
+       "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
+       "      <td>P16</td>\n",
        "      <td>-</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>out</td>\n",
-       "      <td>out</td>\n",
-       "      <td>1.95</td>\n",
+       "      <td>out-like</td>\n",
+       "      <td>in</td>\n",
+       "      <td>1.80</td>\n",
        "      <td>8.0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.917</td>\n",
-       "      <td>2.289</td>\n",
+       "      <td>0.832</td>\n",
+       "      <td>2.131</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -8091,14 +8091,14 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>17.678600</td>\n",
-       "      <td>57.185200</td>\n",
-       "      <td>9.108900</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>16.653601</td>\n",
+       "      <td>54.774502</td>\n",
+       "      <td>0.536291</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -8108,17 +8108,17 @@
       ],
       "text/plain": [
        "     structure.klifs_id structure.pdb_id structure.alternate_model  \\\n",
-       "0                  1061             4wa9                         -   \n",
-       "1                  6755             5hu9                         B   \n",
+       "0                  1047             3qri                         B   \n",
+       "1                  7526             5mo4                         B   \n",
        "..                  ...              ...                       ...   \n",
-       "203                5716             2qoh                         -   \n",
-       "204                5711             3oy3                         -   \n",
+       "203                5702             3mss                         -   \n",
+       "204                5709             1opk                         -   \n",
        "\n",
        "    structure.chain species.klifs  kinase.klifs_id kinase.klifs_name  \\\n",
        "0                 A         Human              392              ABL1   \n",
        "1                 A         Human              392              ABL1   \n",
        "..              ...           ...              ...               ...   \n",
-       "203               B         Mouse              532              ABL1   \n",
+       "203               D         Mouse              532              ABL1   \n",
        "204               A         Mouse              532              ABL1   \n",
        "\n",
        "    kinase.family kinase.group  \\\n",
@@ -8129,81 +8129,81 @@
        "204          <NA>         <NA>   \n",
        "\n",
        "                                      structure.pocket ligand.expo_id  \\\n",
-       "0    HKLGGGQYGEVYEVAVK____________EIKPNLVQLLGV_IITE...            AXI   \n",
-       "1    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            66K   \n",
+       "0    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            919   \n",
+       "1    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIIIE...            NIL   \n",
        "..                                                 ...            ...   \n",
-       "203  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            P3Y   \n",
-       "204  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIIIE...            XY3   \n",
+       "203  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            STI   \n",
+       "204  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            P16   \n",
        "\n",
        "    ligand_allosteric.expo_id ligand.name ligand_allosteric.name  \\\n",
        "0                           -        <NA>                   <NA>   \n",
-       "1                         66K        <NA>                   <NA>   \n",
+       "1                         AY7        <NA>                   <NA>   \n",
        "..                        ...         ...                    ...   \n",
-       "203                         -        <NA>                   <NA>   \n",
+       "203                       MS7        <NA>                   <NA>   \n",
        "204                         -        <NA>                   <NA>   \n",
        "\n",
        "    structure.dfg structure.ac_helix  structure.resolution  \\\n",
-       "0             out                 na                  2.20   \n",
-       "1             out                out                  1.53   \n",
+       "0             out                out                  2.10   \n",
+       "1             out                out                  2.17   \n",
        "..            ...                ...                   ...   \n",
-       "203            in                 in                  1.95   \n",
-       "204           out                out                  1.95   \n",
+       "203           out                out                  1.95   \n",
+       "204      out-like                 in                  1.80   \n",
        "\n",
        "     structure.qualityscore  structure.missing_residues  \\\n",
-       "0                       5.6                          13   \n",
-       "1                       7.6                           0   \n",
+       "0                       8.0                           0   \n",
+       "1                       8.0                           3   \n",
        "..                      ...                         ...   \n",
-       "203                     8.0                           0   \n",
+       "203                     7.6                           0   \n",
        "204                     8.0                           0   \n",
        "\n",
        "     structure.missing_atoms  structure.rmsd1  structure.rmsd2  \\\n",
-       "0                          4            0.862            2.189   \n",
-       "1                          0            0.918            2.301   \n",
+       "0                          0            0.928            2.279   \n",
+       "1                          8            0.864            2.218   \n",
        "..                       ...              ...              ...   \n",
-       "203                        0            0.779            2.135   \n",
-       "204                        0            0.917            2.289   \n",
+       "203                        0            0.921            2.303   \n",
+       "204                        0            0.832            2.131   \n",
        "\n",
        "     structure.front  structure.gate  structure.back  structure.fp_i  \\\n",
-       "0               True           False           False            True   \n",
+       "0               True            True            True           False   \n",
        "1               True            True            True           False   \n",
        "..               ...             ...             ...             ...   \n",
-       "203             True           False           False            True   \n",
+       "203             True            True            True           False   \n",
        "204             True            True            True           False   \n",
        "\n",
        "     structure.fp_ii  structure.bp_i_a  structure.bp_i_b  structure.bp_ii_in  \\\n",
-       "0              False             False             False               False   \n",
+       "0              False             False              True               False   \n",
        "1              False              True              True               False   \n",
        "..               ...               ...               ...                 ...   \n",
-       "203            False             False             False               False   \n",
+       "203            False              True              True               False   \n",
        "204            False              True              True               False   \n",
        "\n",
        "     structure.bp_ii_a_in  structure.bp_ii_b_in  structure.bp_ii_out  \\\n",
-       "0                   False                 False                False   \n",
+       "0                   False                 False                 True   \n",
        "1                   False                 False                 True   \n",
        "..                    ...                   ...                  ...   \n",
-       "203                 False                 False                False   \n",
-       "204                 False                 False                 True   \n",
+       "203                 False                 False                 True   \n",
+       "204                 False                 False                False   \n",
        "\n",
        "     structure.bp_ii_b  structure.bp_iii  structure.bp_iv  structure.bp_v  \\\n",
-       "0                False             False            False           False   \n",
-       "1                False              True             True           False   \n",
+       "0                False              True            False            True   \n",
+       "1                False              True            False            True   \n",
        "..                 ...               ...              ...             ...   \n",
-       "203              False             False            False           False   \n",
-       "204              False              True             True           False   \n",
+       "203              False             False             True           False   \n",
+       "204              False             False            False           False   \n",
        "\n",
        "     structure.grich_distance  structure.grich_angle  \\\n",
-       "0                   13.955400              47.188801   \n",
-       "1                   18.198700              60.844898   \n",
+       "0                   18.143700              59.950401   \n",
+       "1                   19.025999              63.105900   \n",
        "..                        ...                    ...   \n",
-       "203                 16.910601              57.076801   \n",
-       "204                 17.678600              57.185200   \n",
+       "203                 18.569700              62.892899   \n",
+       "204                 16.653601              54.774502   \n",
        "\n",
        "     structure.grich_rotation structure.filepath  \n",
-       "0                   49.136799               <NA>  \n",
-       "1                   25.582899               <NA>  \n",
+       "0                    8.298940               <NA>  \n",
+       "1                   16.033001               <NA>  \n",
        "..                        ...                ...  \n",
-       "203                 20.159500               <NA>  \n",
-       "204                  9.108900               <NA>  \n",
+       "203                 14.525800               <NA>  \n",
+       "204                  0.536291               <NA>  \n",
        "\n",
        "[205 rows x 41 columns]"
       ]
@@ -8587,7 +8587,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ed36ee3c8dc43c2810d22da31b9fee9",
+       "model_id": "b8f612fba65942df989b70f5a57e83b0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -8771,7 +8771,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "774ac1db9fa247b0b53a1e8dbcba8581",
+       "model_id": "315b4d95a5ac4ca58b7cd34aa76cbfcc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -8801,7 +8801,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b41006316170470d96009fd835a70d03",
+       "model_id": "e69f49d4202e482fb06ace8e29424dc7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -8970,7 +8970,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6d1a4fd2821246deae2f7a89a78679de",
+       "model_id": "fa7e28411a5f4b68b0fa1ed0b0d80dd2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9023,6 +9023,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Remote__"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 82,
    "metadata": {},
@@ -9030,7 +9037,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "51bf67e3770e496e8b40a7207db19ce7",
+       "model_id": "8dd6d58e8ebb46fbaaf65e48b56a20bc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9086,6 +9093,7 @@
        "      <th>ligand.bioactivity_standard_units</th>\n",
        "      <th>ligand.bioactivity_pchembl_value</th>\n",
        "      <th>species.chembl</th>\n",
+       "      <th>ligand.klifs_id (query)</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -9099,6 +9107,7 @@
        "      <td>nM</td>\n",
        "      <td>10.80</td>\n",
        "      <td>Oryctolagus cuniculus</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -9110,9 +9119,11 @@
        "      <td>nM</td>\n",
        "      <td>10.70</td>\n",
        "      <td>Gallus gallus</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
+       "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
@@ -9132,6 +9143,7 @@
        "      <td>nM</td>\n",
        "      <td>7.37</td>\n",
        "      <td>Homo sapiens</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -9143,10 +9155,11 @@
        "      <td>nM</td>\n",
        "      <td>6.61</td>\n",
        "      <td>Homo sapiens</td>\n",
+       "      <td>200</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>9 rows × 8 columns</p>\n",
+       "<p>9 rows × 9 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -9171,14 +9184,21 @@
        "7                              43.000                                nM   \n",
        "8                             247.000                                nM   \n",
        "\n",
-       "    ligand.bioactivity_pchembl_value         species.chembl  \n",
-       "0                              10.80  Oryctolagus cuniculus  \n",
-       "1                              10.70          Gallus gallus  \n",
-       "..                               ...                    ...  \n",
-       "7                               7.37           Homo sapiens  \n",
-       "8                               6.61           Homo sapiens  \n",
+       "    ligand.bioactivity_pchembl_value         species.chembl  \\\n",
+       "0                              10.80  Oryctolagus cuniculus   \n",
+       "1                              10.70          Gallus gallus   \n",
+       "..                               ...                    ...   \n",
+       "7                               7.37           Homo sapiens   \n",
+       "8                               6.61           Homo sapiens   \n",
        "\n",
-       "[9 rows x 8 columns]"
+       "    ligand.klifs_id (query)  \n",
+       "0                       100  \n",
+       "1                       100  \n",
+       "..                      ...  \n",
+       "7                       100  \n",
+       "8                       200  \n",
+       "\n",
+       "[9 rows x 9 columns]"
       ]
      },
      "execution_count": 82,
@@ -9198,7 +9218,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "405c08af4e6c4ee19ba9a3107284eb8d",
+       "model_id": "083f8918e5044805ae1ccecb4bfd5af2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9247,6 +9267,247 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Bioactivities from ligand Expo ID(s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Remote__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebd339e7212b49ca8483c973301537e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Processing...'), FloatProgress(value=0.0, max=2.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:opencadd.databases.klifs.core:There was (were) 1/2 failed request(s).\n",
+      "Show error messages (up to 5 messages only):\n",
+      "ERROR:opencadd.databases.klifs.core:Error for PRC: Expected type to be dict for value [400, 'KLIFS error: This ligand is not available in ChEMBL.'] to unmarshal to a <class 'abc.Error'>.Was <class 'list'> instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>kinase.pref_name</th>\n",
+       "      <th>kinase.uniprot</th>\n",
+       "      <th>ligand.bioactivity_standard_type</th>\n",
+       "      <th>ligand.bioactivity_standard_relation</th>\n",
+       "      <th>ligand.bioactivity_standard_value</th>\n",
+       "      <th>ligand.bioactivity_standard_units</th>\n",
+       "      <th>ligand.bioactivity_pchembl_value</th>\n",
+       "      <th>species.chembl</th>\n",
+       "      <th>ligand.expo_id (query)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Activin receptor type-1</td>\n",
+       "      <td>Q04771</td>\n",
+       "      <td>Kd</td>\n",
+       "      <td>=</td>\n",
+       "      <td>620.00</td>\n",
+       "      <td>nM</td>\n",
+       "      <td>6.21</td>\n",
+       "      <td>Homo sapiens</td>\n",
+       "      <td>1N1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Activin receptor type-1</td>\n",
+       "      <td>Q04771</td>\n",
+       "      <td>Ki</td>\n",
+       "      <td>=</td>\n",
+       "      <td>79.43</td>\n",
+       "      <td>nM</td>\n",
+       "      <td>7.10</td>\n",
+       "      <td>Homo sapiens</td>\n",
+       "      <td>1N1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>279</th>\n",
+       "      <td>Wee1-like protein kinase 2</td>\n",
+       "      <td>P0C1S8</td>\n",
+       "      <td>Kd</td>\n",
+       "      <td>=</td>\n",
+       "      <td>481.00</td>\n",
+       "      <td>nM</td>\n",
+       "      <td>6.32</td>\n",
+       "      <td>Homo sapiens</td>\n",
+       "      <td>1N1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>280</th>\n",
+       "      <td>Wee1-like protein kinase 2</td>\n",
+       "      <td>P0C1S8</td>\n",
+       "      <td>Kd</td>\n",
+       "      <td>=</td>\n",
+       "      <td>200.00</td>\n",
+       "      <td>nM</td>\n",
+       "      <td>6.70</td>\n",
+       "      <td>Homo sapiens</td>\n",
+       "      <td>1N1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>281 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               kinase.pref_name kinase.uniprot  \\\n",
+       "0       Activin receptor type-1         Q04771   \n",
+       "1       Activin receptor type-1         Q04771   \n",
+       "..                          ...            ...   \n",
+       "279  Wee1-like protein kinase 2         P0C1S8   \n",
+       "280  Wee1-like protein kinase 2         P0C1S8   \n",
+       "\n",
+       "    ligand.bioactivity_standard_type ligand.bioactivity_standard_relation  \\\n",
+       "0                                 Kd                                    =   \n",
+       "1                                 Ki                                    =   \n",
+       "..                               ...                                  ...   \n",
+       "279                               Kd                                    =   \n",
+       "280                               Kd                                    =   \n",
+       "\n",
+       "     ligand.bioactivity_standard_value ligand.bioactivity_standard_units  \\\n",
+       "0                               620.00                                nM   \n",
+       "1                                79.43                                nM   \n",
+       "..                                 ...                               ...   \n",
+       "279                             481.00                                nM   \n",
+       "280                             200.00                                nM   \n",
+       "\n",
+       "     ligand.bioactivity_pchembl_value species.chembl ligand.expo_id (query)  \n",
+       "0                                6.21   Homo sapiens                    1N1  \n",
+       "1                                7.10   Homo sapiens                    1N1  \n",
+       "..                                ...            ...                    ...  \n",
+       "279                              6.32   Homo sapiens                    1N1  \n",
+       "280                              6.70   Homo sapiens                    1N1  \n",
+       "\n",
+       "[281 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote.bioactivities.by_ligand_expo_id([\"PRC\", \"1N1\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1d4ce85c2bba46baaccc774b021e1ad4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Processing...'), FloatProgress(value=0.0, max=1.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:opencadd.databases.klifs.core:There was (were) 1/1 failed request(s).\n",
+      "Show error messages (up to 5 messages only):\n",
+      "ERROR:opencadd.databases.klifs.core:Error for XXX: Expected type to be dict for value [400, 'KLIFS error: Could not find a ligand with the provided ID.'] to unmarshal to a <class 'abc.Error'>.Was <class 'list'> instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Input values yield no results.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    remote.bioactivities.by_ligand_expo_id(\"XXX\")\n",
+    "except SwaggerMappingError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Local__\n",
+    "\n",
+    "This information is not available locally."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Interactions\n",
     "\n",
     "Explore access to interaction information."
@@ -9268,7 +9529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -9338,7 +9599,7 @@
        "[7 rows x 2 columns]"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9372,7 +9633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -9417,18 +9678,18 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9786</th>\n",
-       "      <td>13034</td>\n",
-       "      <td>0000000000000010000001000000100000010000000000...</td>\n",
+       "      <th>9788</th>\n",
+       "      <td>13041</td>\n",
+       "      <td>0000000000000010000001000000000000000000000000...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9787</th>\n",
-       "      <td>13035</td>\n",
-       "      <td>0000000000000010000001000000100000000000000001...</td>\n",
+       "      <th>9789</th>\n",
+       "      <td>13042</td>\n",
+       "      <td>0000000000000010000001000000000000000000000000...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>9788 rows × 2 columns</p>\n",
+       "<p>9790 rows × 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -9436,13 +9697,13 @@
        "0                      1  0000000000000010000000000000000000000000000000...\n",
        "1                      3  0000000000000010000000000000000000000000000000...\n",
        "...                  ...                                                ...\n",
-       "9786               13034  0000000000000010000001000000100000010000000000...\n",
-       "9787               13035  0000000000000010000001000000100000000000000001...\n",
+       "9788               13041  0000000000000010000001000000000000000000000000...\n",
+       "9789               13042  0000000000000010000001000000000000000000000000...\n",
        "\n",
-       "[9788 rows x 2 columns]"
+       "[9790 rows x 2 columns]"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9460,7 +9721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -9521,7 +9782,7 @@
        "3                5705  0000000000000010000000000000000000000000000000..."
       ]
      },
-     "execution_count": 87,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9546,7 +9807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -9589,7 +9850,7 @@
        "0               12347  0000000000000000000000000000000000000000000000..."
       ]
      },
-     "execution_count": 88,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9600,7 +9861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -9629,7 +9890,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -9672,7 +9933,7 @@
        "0               12347  0000000000000000000000000000000000000000000000..."
       ]
      },
-     "execution_count": 90,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9683,7 +9944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -9717,7 +9978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
@@ -9794,7 +10055,7 @@
        "[14 rows x 2 columns]"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9805,7 +10066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
@@ -9855,7 +10116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -9925,7 +10186,7 @@
        "[174 rows x 2 columns]"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9936,7 +10197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -9963,7 +10224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
@@ -10019,7 +10280,7 @@
        "1                      509  "
       ]
      },
-     "execution_count": 96,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10030,7 +10291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -10073,7 +10334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [
     {
@@ -10168,7 +10429,7 @@
        "[85 rows x 5 columns]"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10179,7 +10440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [
     {
@@ -10206,7 +10467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [
     {
@@ -10301,7 +10562,7 @@
        "[85 rows x 5 columns]"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10312,7 +10573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
@@ -10352,7 +10613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10375,7 +10636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
@@ -10521,7 +10782,7 @@
        "[3604 rows x 11 columns]"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10533,7 +10794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -10584,7 +10845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
@@ -10623,7 +10884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -10655,7 +10916,8 @@
      "output_type": "stream",
      "text": [
       "Pocket (pdb): Number of atoms: 1156\n",
-      "Ligand (mol2): Number of atoms: 49\n"
+      "Ligand (mol2): Number of atoms: 49\n",
+      "Ligand (pdb): Number of atoms: 31\n"
      ]
     },
     {
@@ -10669,7 +10931,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ligand (pdb): Number of atoms: 31\n",
       "Water (mol2): Number of atoms: 3\n"
      ]
     }
@@ -10696,7 +10957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -10723,7 +10984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -10738,8 +10999,7 @@
      "output_type": "stream",
      "text": [
       "Complex (mol2): Number of atoms: 3604\n",
-      "Protein (mol2): Number of atoms: 3552\n",
-      "Pocket (mol2): Number of atoms: 1156\n"
+      "Protein (mol2): Number of atoms: 3552\n"
      ]
     },
     {
@@ -10753,6 +11013,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Pocket (mol2): Number of atoms: 1156\n",
       "Pocket (pdb): Number of atoms: 1156\n",
       "Ligand (mol2): Number of atoms: 49\n"
      ]
@@ -10810,17 +11071,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3de1xU1doH8N/MMIDDMFwU8YKIiKCCF8I0JVOTNBLMULLjpYtvgaeOaGYOeQNTc5IyNE3JNHk7+Sk6+RZ2U0wzzAzBBBQEQbxwEQQGhjvMzHr/2EgcvKQwM5uZeb6f/mD27NnrGcyfa6+199oCxhgIIYR0lpDvAgghxLhRjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBKiS2q1WqlU1tTU8F0IMRwLvgsgpLs4ehRz5+LiRTg54ckn8dNP+L//Q2oqNBrU1ECtRm0tWlpQX4+mJjQ0AJheVVXU0NDQ1NRUX1/f0tJSW1vLHcrPzy88PPyVV17h9QsRA6EYJeQvM2di/Xrs2NH68osvkJBw15179rxWUXGxw0aRSCSTyXJycsLCwmxsbObNm6e3Ykl3QTFKWuXm5lpbW/fr18/Cwnz/r/D2RlERMjJaX4aEYORIWFhAKoVYDBsbWFqiRw9YW8PaGhJJgqWlQCKRiMViqVRqYWFha2vLffDTTz9dtGjR8uXLAwMDHRwcePs+xCAEdE894fj4+Fy4cCEzM9PHx4fvWvhx9CjOncP//A/CwlBTg59+6vyhGGMBAQHHjh1bvHjxrl27dFcj6Y5oiom0qqysBODo6Mh3Ibz57TccOQILC0yZgoKCLh1KIBDs2rXLysrq448/PnXqlI4KJN0UxShpZeYxqlbjwAEkJeHLL/Hqq8jJ6eRxDh48uGXLFgCenp4rVqzQarWLFy9uaWnRZa2km6GTegIAtbW1tra2NjY2bXPN5mb3bvzzn/D0xPnzEIs7eZDc3Nzhw4cLBIK0tLSRI0c2NTWNGjUqJycnJiZmxYoVOq2XdCPUGyWA2XdFGxqwaRMAbNrU+QwF4Onp+a9//UutVr/yyitardbKymr79u0AoqKiCro4TEC6MYpRAgAVFRUAevbsyXch/PjgAxQWYswYzJ4NAF25dn7Dhg0uLi4pKSkff/wxgGnTpv3jH/9Qq4Xvv1+io2JJt0MxSoBbvVHzjFGlEu+/DwAKBQQCNDZi5EjMnw+VqjNHs7W13bZtGwC5XF5cXAxg69YPhg0r27lzwsGDuiybdB8UowS41Rs1z5P6d95BZSWmTcPUqQCwcyeuXEFmJqTSTh4wJCQkODhYpVKtXq0A0KePc3h4DwD/+heqq3VWNuk+KEYJYMa90aIifPQRBAK88w4AVFdj82YAePddCLvwl+PDDz98/PF9iYnbjhwBgPBwTJiAkhJER+ugZtLdUIwSwIx7ozt35jc24tln4ecHADExqKjAxIkIDOzSYQcOHPjkky9VVgpeew0NDRAKsXs3xGJ8+CHOntVJ4aQboRglgLnO1GdnZ2/Z4jV06LyNG9UAysqwfTsAKBQ6OPjrr2P0aOTltfZzR4zA0qXQaBAeDo1GB8cn3QfFKAHMdaZ+1apVGo1m0iR7Dw8LAFu3KmtqMGsWJkzQwcEtLBAXB6EQW7YgKwsA1q/HoEFITQXdHWpiKEYJYJa90ZSUlG+//dbGxmbt2rUA8vLyPvig7/jxMZs2aXXVxNixCAtDczMWLwZjkEiwcycArF6NoiJdNUL4RzFKALPsjUZGRjLGXn/99b59+wJYs2ZNc3PT8OE5w4fr8i/F5s3o0wcFBbh+HQACA/HMM6ivx7FjOmyE8IxuBiUAMGzYsIsXL2ZnZw8dOpTvWgzhhx9+mDFjRq9evfLy8uzs7NLT0x966CFLS8vc3NwBAwbotq3UVHh54dYSeigqQlkZfH112wjhE/VGCWBmM/VarXbNmjUAVq1aZWdnB+DNN9/UarVLlizReYYCGDPmrwwF0L8/KirQsydu3gSAJ5/UeYPE0ChGCRhjSqVSIBCYyQLDBw4c+PPPP/v377948WIAJ06cSEpKsre3l8vlBquBW2afmAaKUQKVSqVWq2Uymbgry3IYiebm5ujoaACbNm3q0aMHgK+//hrAypUrDTk07O0NsfivZfaJUaMYJeZ1Ri8Wi2fMmCGTyYKDg7kt27dvP3z48NKlSw1cybp12LDBwG0SvaAYJeY1Tc8YS01NValU69udVE+bNk0ikRimAK0WaWkA4OCgg2X2SXdAMUrM66JRoVAYFxcnFot37Njxxx9/GL6AL79EZCTOnAHQpWX2SfdBMWruGGNJSUkwm94oAB8fn2XLlmm12tdee01j2BszW1qwdi0ATJ9uyGaJflGMmi+tVnvo0KGxY8e+//77Y8eOXb58Od8VGU50dPSgQYPS0tJ2cvcVGUpcHPLz4eWF5583ZLNEvyhGzZFarf7ss898fHxmzpyZmprav3//+fPn+3FrHJkHiUTCBeiaNWsKCwsN02htbeujShQKWFgYpk1iEIyYk+bm5vj4eE9PT+5Pf+DAgbGxsQ0NDXzXxY+QkBAAs2fPNkxz69czgI0dy7RawzRIDIRuBjUXTU1N8fHxGzduvH79OgB3d3e5XP7SSy+Zw7Wid1NSUjJs2LDq6urExMS265/0pLwcgwdDpcKxY5gyRa9NEYPjO8eJ3tXW1sbGxvbr14/7E/fx8YmPj1er1XzX1S1wz01ydXWtqanRa0NLlzKAzZih10YIPyhGTZlKpYqNjXV2duYCdNSoUfHx8RqNhu+6uhGNRjNu3DgAK1eu1F8rBQUaKysmFLJz5/TXCOENndSbpvLy8h07dmzfvl2pVALw9/eXy+VBQUECgYDv0rqdtLS0cePGCQSCM2fOjB49Wh9NvPjiory8R0aNmrdzZ2efk0e6M75znOhYaWlpVFSUTCbj/nz9/f0TExP5Lqq7i4iIADB27Fh9dNUzMjKEQqGlpWV+fr7OD066A4pR03H16tWIiAhuuQ0AAQEBv//+O99FGQeVSuXi4gIgLi5O5wefMWMGgKVLl+r8yKSboJN6E6HVaj09PfPz84VCYUhIyOrVq/V0fmqqvv766zlz5tjZ2WVnZ3Pr4XPUanVVVZVKpdJqtdXV1YyxqqoqANxoSXV1tVarValUGo2mpqZGrVZPnDiRy03OyZMnJ06cKJVK8/Ly2gapianhO8eJbsybN08qlU6ZMiUrK4vvWowVd83T/Pnz229M49YRuW8rVqxo/3F/f38A69evN+xXIQZFvVETERAQ8PPPPyclJQUEBPBdi7G6du2at7d3bW1t+19jTk6Ov7+/nZ2dQCCwt7cHwC1ubW9vLxAIZDKZSCSytbW1sLCQSqVisXjcuHGTJ0/mPvvtt9/OmjXLyckpPz/ftv0K+MS00C1pJsKsFrvTE1dX17Vr18rl8n/+85+ZmZnW1tYAvLy8ysvLO3E0jUazevVqAOvWraMMNW10T72JMKvF7vRn+fLlo0ePzsvL27x5cyc+Xl1drVQqr169evny5U2bNl24cMHNze2VV17ReZ2kW6GTehMhlUrr6upqamqkUroysUtSUlLGjx8vEokWL14skUhaWlpqa2vVanVNTY1Go7nbXFNVVdXtf5VsbGx27969YMECHr4GMSCKUVPQ3NxsZWVlaWnZ1NTEdy2mYOzYscXFxUVFRQ/6QW6olBsktbGx+frrrwcPHiwU0jmfiaOxUVNAA6M6VFJSkpWVVVdX9+KLLw4dOtTCwsLW1lYkEslkMqFQeLe5Jjs7O4pLs0UxagrM6pl0+vb222/X1dWFhIR8+umnfNdCjAP9+2kKuPkl6o123aVLl/bu3SsSiTbQQzvJfaPeqCkQi2vmzx/Rr98gvgsxemvWrGlpaXn55ZeHDx/Ody3EaNAUkykoL9979erLvXr9z8CBn/BdixFLS0t7+OGHrayscnNzBwwYwHc5xGjQSb0pUKsrAIhENDbaJZGRkYyxiIgIylDyQChGTYFGUwnAwoLGRjvvl19+OXr0qL29vVwu57sWYmQoRk0B1xu1sKDeaCcxxiIjIwFERkbSBQ/kQVGMmoJbMUq90U5KSEj4448/+vXrt2TJEr5rIcaHYtQUcCf1NDbaOWq1Ojo6GkB0dLREIuG7HGJ8KEZNAfVGu2LPnj0XL1709PR86aWX+K6FGCWKUVNAMdppDQ0NmzZtAvDOO+9YWNBl1KQzKEZNgVpNJ/WdtHXr1qKioocffjgkJITvWoixosvvTYC2tHSrRlPVr99GvisxMkqlcvDgwUql8ujRo1OnTuW7HGKs6CyGJ4xBLodKhZYWDBmCyEgcOgS1GmVl+PxzODqiZ084OsLREb16oWfPJr/e2t4yC4ueIpGjUNij7TCNjReLilaJxf0Ya+Dx2xipjRs3KpXK6dOnU4aSrqDeKE8OHEBhIVauBICICMyZg8ceA4AlS7Bjx+27X/nZv8LuN+5nobAHl6cWFo49evja2Pg5Os7n3qqrO8NY4613ewoEYsN8G2NUVFQ0ZMiQxsbG1NTUhx56iO9yiBGj3ihP0tMRFNT68/jxSE9vjdE338Szz6KiApWVqKho/a+yUmwr7dFDpVZXajQVWm1Dc3MhUAigT5/I2trfrl59xcLCsV+/jUVFkTU1x9oaEYlsuTx1jx9mdVXzVw+X+6FnT/j5QWymUbtmzZqGhoZ//OMflKGki6g3ypN//xulpXjjDQB4/XU8/TRuPU7yb2m19Wp1pUZTqVZXSCR+IpEMQGHhSpksoLr6x/r6VC5t1epKxlq4j4wI72eZVnyHY1VVYdOmO4wtPPPMvWtIUak+Ki72lEjsRaJX+/e/32/dbVy8eHHEiBECgSArK8vDw4Pvcohxo94oT+bNw8qVeO01tLTAze3+MxSAUCixtJQALgCqqr5RqQ4LBJYtLSU2NmNlsmnt99RoVFzaimMqcaO8tYdbWdn6Q1UVvvsOvXphyxYAiIjAr78iOPg+y5hsb/9inz73Xzbv6urq8m/Zu3evWq1+9dVXKUNJ11GM8kQoxHvvdf0w9vazhEJJbe1JB4c5IpF9h3dFIplIJLO0dMOUu3xeLr/z2MJ9+KWqqri52cfGZmb3Wy5aqVRevs2VK1e0Wi23g1AotLW1nT17Nr91EtNAMWr0VKojpaXvi0R2UunEB/7wiBFIScHEiQCQkoKnn77/j3aH3ihjrLCwMP823DM7O7Cysho0aNDgwYMHDx6ckZHxyy+/7Nmz5/HHHzd82cTEUIwavS4t79SFsQUenT59+p133snLyysoKGhsbLx9B5lMNvi/eXh4uLi4tD11rqSkxN3d/auvvoqOjvby8jJs+cTUUIwavVtrNnfqzLqzYwvpdXW59fVZdXXDbWw6024XJCcnb9q06fDhw9xLBwcH99sMGjRIIBDc4yB9+/Z98cUXd+/erVAo6NF1pIsoRo0eL2s2n62pOVNTE9q7tyEb5Zw4ceLw4cMzZ858++23Bw8eLJVK771/aWlpfn5+Xl4ed77/9ttvu7u7A3jrrbf27dv32WefrV69miaaSFdQjBo9XtZsrtZoANiLRIZslJOZmQkgJCRk1KhRHd5SKpUXLlzIyspqm1a6dOmSSqVqv8/cuXO5GHV1dZ03b97+/fvfe++93bt3G6x+YnooRo0eL8s7VavVAGR8LInExejIkSO5l8ePH4+JicnPz79y5Upzc/Pt+zs6OrYfJPX19W17a/Xq1Z999tm+fftWrVrl6upqmPqJ6aEYNXZMo1ECApHIwZCtqtRqAHYGj9GmpqZLly5ZWFgMGzaM21JTU/Pjjz9yP98+Turt7d23b9+7Hc3DwyM0NPSLL77YunVrbGysIb4AMUV0F5Nxa2hoOnNmobV1/dix3xms0WbGJpw9KxYIfjf4bZRpaWljxozx9vY+f/48t+XmzZunTp3iepo9evS498dvl5WVNWLECEtLy8uXL98jcAm5B1pv1LiVlFhNmpTw3HOGy1DcOqM3fFcUQEZGBoARI0a0bXFycnr66ad9fHw6kaEAhg8fPnPmzMbGxm3btumsSmJmKEaNW2UlABj4NiK+zuhxa2C0fYx23bp16wQCwY4dO8rLy3V4WGI+KEaNW0UFABj4kcCtvVH+punb5pd0wtfXd/r06XV1dTvutEQhIX+LYtS48dMbbW4GT9P0paVi6Lo3CmDdunUAYmNj73gXKSH3RjFq3HjpjeZ/882fjzzSsHOnQVsFSkuRmfmDq6tG5xcnjR8/fvLkydXV1bt27dLtkYk5oBg1brz0RsvLy7VqtdTg6z2npwOAm5vw3jd6ds6aNWsAvP/++7W1tTo/ODFtFKPGjZfeaGVlJQBHA7cKZGQAgE7HRf8ydepUf3//ioqKPXv26KUBYrooRo2bpSWcnODkZNBGuRjtafBlRjMzAUDX46J/eeuttwBs2bKloYGeD0geAMWocYuJQVkZ5s0zaKMVFRXgrzeqvxidMWPGmDFjbty4sX//fn21QUwRxahxOHoUCkXrzwEBrVt69sTNmwDw5JMGLYaX3qhajexsCATw9tbxkdvfyBcZGQlAoVDc8fZ8Qu6IYtSIzZyJ9et5aJeX3mhODpqa4O4OmUyXhy0oKHjkkUcuXLjAvQwJCfHx8bl27dratWspScl9ohg1Gt98g8WLsXgxSktbt3h7QyxuPdU1JF56o/qYX8rKyvL3909JSYmOjm7b6OLiYm9vv2XLFgcHhyeeeGLbtm3Xr1/XZavE5FCMGo1Zs7B7N3bvhrPzXxvXrcOGDa0/r12L//zHEJXwMlPPzS/pMEbPnTs3efLkkpKSSZMm7du3D4BWqw0PD//pp5/q6uo8PDzq6+uPHj26bNkyV1dXX1/fVatWnTx5UqPR6KwCYiooRo2bgwOmTEFBAVJSsGkTQkMxb17rxaT6kJ6evmDBArFYLJVKt23b1vagTQN47DG89hqm3O0Rpw8oLS0tICDg5s2bgYGBP/74o62trUajWbRo0Z49eyQSyXfffXfp0qVr167FxcXNmjVLKpWeO3du8+bNEydO7N2797Jlhf/7v62j0oQAACMmQatlcXFMKmUAc3Zm33yj4+OfPHkyMDCQ+3/G0tKS+2HKlCkFBQU6bkn/kpOTZTIZgODg4MbGRsZYU1PTnDlzANjY2Pz8888d9m9paUlOTpbL5X5+flZWMhsbLcCEQubnx+RylpzMNBo+vgbpNihGTUpBAZsyhQEMYKGhrLJSB8dMTk4OuvUse6lUGhERUVRU9P333/fr1w+ARCKJjY3VarU6aOkukpKYoyMrK2OMsenTu3q048ePc49veu6555qbmxljjY2Ns2bNAmBvb3/q1Kl7fzw//8b27ezJJ5m1devvGWC9e7MXXmBffqmbXzgxOhSjpobrltrYMIC5urKkpM4fKikpafz48VyA2trayuXyioqKtneVSuWCBQu4d6dNm3b9+nUdVH/nMtiLL7LXXmOsyzH6/fffW1tbA1iwYIFarWaM1dXVPfHEEwAcHR1TUlLu/1D19SwpicnlbOjQv/J0wQJdJj4xFhSjpikri40dywAmELDo6GO1tbX3/1mtVpuYmPjwww9zEdmrV6+oqCilUnnHnRMSEnr16gXAzs4uLi5OR+UzxlhlJYuOZps3s6QkFhPDli1j6els+nTW3MzeeosVFT3wARMTE62srAAsXrxYo9EwxmpqaqZMmQLA2dk5IyOj06VeuMBiYtjjj7MPP9RZ4hMjQjFqslpamELBxo0rFwiEgwYNOn78+N9+RKPRJCYmtj30rXfv3gqFoq6urm2HlJSUAwcOdPjUjRs3uJNiAE899VRRJxLuv5WWsshIZmvLACaTsW+/ZTExrLKSzZnDpk9nH37IACaRMLmc3SXb7+DAgQMWFhYA3nzzTW6LUql85JFHALi6uubm5naxZk6HxCdmgmLUxJ07l849iFgoFK5YsaKhoeGOuzU3N8fHx3t5eXFpOHDgwNjY2Pr6+rYdTp48GRQUJBAI7Ozs7tgzTUhIcHBwAODk5PSf//ync9XeuMHkciaRtJ4j+/uzo0dbs4kxtnMn8/RkFy+y0FAmEDCAOToyhYK1K/POPv74Y6FQCEAul3NbSktLuV+Lm5tbfn5+56q9HVdqW+ITM0ExavpaWloUCoVYLAYwbNiwDiOATU1N8fHxgwcP5gJ00KBBsbGx3Pw158iRI4899hj3rkwmi4yMrKqqumNDxcXFM2bM4PYMDQ0tLy+//yKvXGEREaxHj9aBiKAgdvr0vfZPSWGPP96atv37s7g41tJy5z137drFLaz37rvvcltKSkp8fHwAeHl5FRYW3n+Rf6st8T/4gLm4sLv8noipoRg1F+fOneP6XxYWFnK5vKmpqba2NjY2tn///lzweXt7x8fHt7RLo6SkJO60lwvQDlNMd6TVauPi4ripcGdn52/u48KrnJycJUs2W1oy7iqiuXNZevr9fqmffmK+vq1hOmwYS0xU3X7NwOnTp2UyWWxsLPfy6tWrHh4eAIYPH15cXHy/LT2ggAAGsIMH9XR40r1QjJqRhoaGN954gzu9HThwYNttSH5+fgcPHmwLIG6EdMyYMdy7Tk5O95hiuqPLly9Pnjy5rVtaeZfrgDIzMxcuXMgNWY4fXxQayrKzH/hLabUsIYENGcIA5uv7xtixY48dO9Zhn9LS0rbCBg0axH3lB+osP6ioKAawpUv11wLpRihGzc6pU6fc3Nz69OkDYMKECYmJie0DNCEhYdiwYVwCOjs7d5hiun9ct1QikXBzOEePHm3/7pkzZ2bNmsWda1tZWYWHhxcUXOnKl2puZp98Uu586z7ZwMDAc+fOddgnOzub63o/+uij1dXVXWnubx0/zgA2erReGyHdBcWoOdq7dy93sWfbFm6KydPTs/0U093mo+5fVlYWd+GUQCAICwurqalpm6riAjQsLEyHF5zW1tYqFAp7e3uuxdDQ0EuXLnFv/fnnn05OTgAmTZqkUql01WJ7KhX74Qf222+MMdbQwKytmVDI/m4UhJgCilFztG3bNgBLlixp28Kts8nNuuzfv7/lbvM1D66lpWXDhg3c/aPcVH7bxfxt59q6VVFRIZfLucvsxWJxWFjY4cOHufWoAgMD6/92Xr+zPvmEAWz27NaXEycygCUm6qk10o1QjJqjqKgoAFFRUW1brl696ufn98UXX2j0c394Zmamm5ubq6urRCK5n6mqrrty5coLL7zADQRzIR4SEtLU1KS/Fi9dYgBzcmLcGMmaNQxgb7yhvwZJd0ErPJkjbt3l9guGurq6pqamzp07l8sdnfPx8XnmmWeuXbsWGRmpUCgMsMjewIED9+/fn56ePnHiRDs7Ozc3ty+//LJtURV98PBA//64eRPZ2QAwaRIAnDihvwZJd0Exao54WTC0qqoKQNv1VYbh4+Nz4MCBmzdvKpVKfTyWuQPu+louOidMgKUl/vwT1dX6bpbwjGLUHN3eG9WH/Pz8BQsWxMTEcC/5ep6oi4uLu7t7dXV1Ovece31q3wOVSODnB40Gv/2m72YJzyhGzZFhEu3y5cuff/75kSNHuJd8PU8UwKRJkwCc0P8JNnex7IkT4J6SFxJyZsSIxSdPRum7XcIvilFzZJhE69Dn5as3CgPGqJcXgoKSevZclJOTA2DEiMrMzLhjxw7ru13CL4pRc2SYk/oOI7C890aTk5MN8NQTieSTCxc+/fXXEwD8/f3FYnFaWlpNTY2+2yU8ohg1O2q1WqVSiUQimW4fVXybDmGtVCrBU4y6ubkNHDiwsrLy/Pnz+m6rfc9XKpX6+vqq1erff/9d3+0SHlGMmh3u7ngHBwc9XdvUpn1vVKVSNTc329ra6vWSo3vgFqkywHk9F6PHjx9v/9IA7RIeUYyaHcOc0XdoiJdLrNozWJwNHz68d+/eJSUl+fn5hmyX8Ihi1OwYbKqnfXQaLLvvhouzX3/9lXGT6HojEAgeffRR3IrORx99VCQSnTlzpr6+Xq/tEh5RjJodg031dKveqIeHx4ABA27evJnN3WOkT5MmTbKzs+NuN7Czsxs1alRzc/Pp06f13S7hC8Wo2TFYx7B9t5f33igArpP4yy+/6LuhsLCwioqK5cuXcy+5pVe/+uorfbdL+EIxanYMdlLfvtvL40WjbQw2TGltbS0SidpelpaWOjs77969u0+fPs8///xXX31VTfeHmhaKUbNjmPNrrVZbVVUlEAi41T95vGi0DdcrNMDwaBvG2LJlyz7//POKiopevXqVlpZ+9tlnzz77rLOz87Rp0z744IPc3FzDVEL0imLU7Bgm0aqqqjQajb29PfeMEN7HRgF4eXn169fvxo0bhgkvxlhERMS2bdssLS0TEhLKysrOnj27cePGCRMmqNXqpKSk5cuXe3l5eXh4REWV/PQTGhsNUBTRC4pRs8PjLUz8ntTj1vCoAc7rNRrNokWLduzYIZFIDh069MwzzwgEAl9f39WrV//2229lZWUJCQlhYWF9+/YtKqp4772+gYFwdMQTT+Ddd5GTo+/qiI5RjJqd24cp09LSDhw4oNtW7nhDPb+9URhqeLSlpeW5557bv3+/jY3NoUOHpk2b1mEHR0fH0NDQuLi4wsLCX39NeeMN+PmhsRFHjyIyEkOHwtsbb76J48fR0qLXSomO8LpoNOHB6NGjAZw9e5Z72djY6O3tDWD27NllZWW6auWHH34AEBgYyL3kHtR86tQpXR2/c7ibQfv27dt+4/Xr13NycnTVRGNj46xZswDY29s/0PctKWH79rHQUGZn1/rIaIC98AJzdGTcH8v06YwxlpTENm9u/cjUqbqqmnQJ9UbNjqWlpUgkSk1N5V5aWVlFRUU5ODh8/fXXPj4+Bw8e1EkrgYGB1dXV+/fv5152k95oh1uMOLt27fLy8nJ3dw8PD//qq69qa2s7ffz6+vrg4OBvvvnGwcHh8OHD48ePv//P9umDl15CQgLKy3H8OFauhI8PxozBzJlYv77TFRGD4DvHiaElJydzf/QLFy5se/r8lStXpk6dym0PDQ3V+TPcubP7mzdv6vawnRASEgJg7969bVvWrVvXq1evtr8REsbnCnwAAAWcSURBVIkkKCjoo48+KigoeKAj19TUPP744wCcnZ0zMjJ0Um1SEouJYcuWsfT0v3qj48ax8HAWHs58fHTSCOkqilGzwz1BXiqVAujTp0/irWdXdtj+7bff6qpFjUYjEokEAoEOHzjaadxTUZ9//vn2GzUaTWpqqkKh8Pf3b79ii7u7e0RERFJS0t8+C0+pVHIDFwMGDMjNzdVVtVyMVlayOXPopL77ohg1U5cvX+YWPeK6pW2Pbr98+TI3D9Nhe6dlZGTMmzdPJpPZ2trGxcV1ufCu4h4lYmtrGxoaGh8fX1lZ2WEHbhp94cKF3BWvHBsbm6CgoLi4uOvXr99+zLKyMm7E2c3NLS8vT4fVcjHKGNu5k3l6tm7pEKM//MDefZctXarDZsmDoRg1XxqNJjY21srKCsDAgQN//vlnbjvXLZVIJB22P6g//vgjODiYe5CcWCzm8ig4OLikpER3X+KBaTSatlXsAFhYWEycOHHz5s3p6ekd9lSr1ampqVFRUX5+fm2PwwsODu6wW0lJyYgRIwB4eXndMWQN49VX+WqZUIyavQsXLowZMwaAQCAICwurra299/b7kZycHBQU1NaPi4iIKCwsTEhI4EZI7e3tee+W5ufnx8XFBQUFcf+KcHr37r1w4cKEhISqqqoO+1+9enXXrl3BwcH79u3rsH3IkCEAhg8fXlxcbMBv8F9iYlhKCl+NE4pRwlhLS4tCoeAWVHZ3dz9x4sS9t99DcnJy21SVVCqNiIhoHy4lJSUzZ87k3p0zZ053mHGqq6tLTEwMCwtzcXFp30X19/dXKBSpqan3+GxBQYG7uzuAhx56iMfvsm0bmz+fffAB02r5KsHcUYySVhkZGb6+vgCEQmFERERjYyO3/ezZs9xJ61NPPXWPjyclJY0bN46LIZlMJpfLbx925MTHx9va2nK9v4MHD+r+m3TW+fPnFQpFQEBA2xAEgEGDBoWFhSUkJNTU1LTfOTs7u3///gD8/f1v770Ss0IxSv7S3NwcFRXFrU7k7e195swZbntjY+PatWvvOPCn0WgSExP9/Py40HFycoqKivrbWCkoKOAWCgEQuXWrSq3W/ZfpgoqKirabNdvytEePHgEBAQqFIjs7+/z589xbkyZN6vosHDF2FKOko9OnTw8dOpQ7t5XL5Xe71kej0SQkJAwbNoxLGWdnZ4VCUVdXd5+tcBNZPfv0mZmWNi09/US37NBpNJrTp0+vW7duzJgxbbNM3HgFgMDAwPr6er5rJPwTMEMtGkaMSENDw/r162NiYrRa7ciRI+Pj47kLejjNzc1ffPHFxo0bL126BMDNzW3ZsmXh4eHW1tYP2lCBUrmhtDSjrk4APOPktMzFRaLnB+11Wnl5+fHjxw8dOvTdd9/NnTu3rq7uk08+4esJfaRboRgld3Xq1KkXXnghLy9PLBavWrVq7dq1arU6Pj5+w4YNhYWFANzd3eVy+aJFi7jV8DpHC3xZVvZhYWEzY/0sLde5uY2xtdXdl9A9tVrd1NRkY2PDdyGku6AYJfdSU1OzYsWKPXv2MMaGDBlSVVV18+ZNAKNGjVq1atWcOXN09ZTmyw0N0VeuZNXXC4BnevV6fcCAHt21W0pIBxSj5O8dOXLk5Zdftre3z8zMHD16NBeg7ccKdULD2L9LS3cXF7cw1t/KKtrNzVcq1W0ThOgDxSi5L1VVVfX19bm5uW0z7HqSXV8fdeXK5YYGjx49Xndx2VVc7CmR2ItEr/bvr9d2Cek0ilHS7TQzFldcPNXBoVatzqqvf7FPH74rIuReKEZJ95WiUn1UXOwpkfjY2Mzk+wEkhNxN5ydYCTGAyfb21Bsl3RxNhhJCSJfQST0hhHQJ9UYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRL/h/s60VWu6olBAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvomK+y5uIKJkWmJp4laiP/NaSYleLaybNm6Ja3fQFnJJx9stqW4ZZiqaaWSmGGoQKiCmSYgoKjIMw7DNMDPP74+DI+4IszDM9/3qxWvmcHieZ0w+fs95znkOjzEGQgghjcW39AAIIcS6UYwSQkiTUIwSQkiTUIwSQkiTUIwSQkiTUIwSctv58ygrq3t94QI0GouOhlgJilFCbps5E6+9Vvf6n/9EcbFFR0OshNDSAyCkedFq8cMPGDMGAGprUVyMigpotVCpoNOhvBx6PZRKAFCrc6uqjpWVlTHGuK9KpVKv15eXl+t0unnz5vXt29fFxcWyH4eYAcUoIXdYswYvvoinngKAAwcwZ84D9xw+vOTXX2c96LuZmZmDBg363//+Z4IxkuaFYpSQO/j7Izoaa9YAgFgMHx+IxRAI4OoKPh9ubuDx4O4OAN27u3btGuPm5sbn87mvrq6uAoFALBaXlZUtWLDg66+/njZt2nPPPWfZT0RMjUc3gxIAaWlpS5cujYiIWLx4saXHYklPPoldu+DmhqFDUVqKQ4fQpk0jm1q7dq1EIuncuXN2drajo6NRh0maF5piIgBw6dKlw4cP5+TkWHogzYJQiI8/xsWLTWrkX//6V79+/S5evPjee+8ZaVykmaIYJQBQWloKwMvLy9IDsaTDhzF5MlxdASA0FMeOwcenMe0cOHBAr9cLhUKZTMbn8+Pj48+dO2fcoZJmhWKUAIBcLgfg6elp6YFYjE6HuXPxxhvYu7duy+DBcHB47HZmzpw5evRomUwGIDQ09LXXXtNoNLNnz6azZy0YxSgBblWjthyjn3+Oc+fQoQMiI5vUDjehtHDhwqKiIgBr165t1arV0aNHv/jiC6OMkzRDFKMEuFWN2uxBfU0NVq4EgPfeg719k5qaOHHiuHHjysvL3377bQBubm7r1q0DsHnzcbncCEMlzRDFKAFsvhpdvx6FhejbF5MnA4Be36TWNmzY4OLisn379h9++AHAtGnTYmJO/vHHlnfeMcZYSfNDMUoA265Gy8oQHw8Aa9eCz4dOh9BQSCSorGxkg4GBgcuXLwcwb9686mo1gAULQoVCfP45Dh821qhJM0IxSgDbnqmXSlFaimHD8MwzAJCYiD/+wI4dsLNrfJvz5s0bMeJlb+/UNWscAHTujEWLwBj++U+o1UYaN2k26PJ7AgCenp4KhUIul9vacX1REbp0QXU10tIQFoaaGnTrhsuX8fXXmDq1SS2npyMsDEIhTp1Cz57QaNCvH86dw5o1sO1bHFogqkYJdDqdUqnk8/nu3E2OtmTLlhNCIXvhBYSFAcCGDbh8GX36YMqUprY8cCBiYqDRYPZsMAZ7e2zZAh4Pq1cjL6/pAyfNCFWjBHK53Nvb28vLq6SkxNJjMasLFy706tXLw6PzsWMZXbs6l5Whc2fI5ThwAM8+a4T2y8vRoweKivDZZ5gxAwBeeQWJiXjmGRw8aIT2STNB1Six3WvvFy9erNVqJ058smtXZwBbt/5dVobhw42ToQBcXfH++wAwfz5u3gSADz6Ajw9++gnffmucLkhzQDFKbHSaPj09/fvvv3dycnr33XcBXLt2bcWKoI4dJ65bV23EXqZOxbPPwsGh7kDeywtSKZydUV5uxE6IhVGMEhu9aHTRokWMsXnz5rVp0wbAihUrqqqq+vQRhIQ4Gbejzz7DuXN1514BzJiBtDT88gtKSwFAocDy5cbtkJgbxSixxWr04MGDhw4dcnd3X7BgAYC//vrrs88+EwgEq1atMnpfAQFwc7v9lseDmxtSUrBwIQBUV+PIEaP3ScyKYpTY3EWjjDFuWdXFixdzNfiSJUtqa2ujo6N79OhhnjGEhqKoCGlp5umNmBbFKLG5g/rt27dnZmYGBATMnTsXQEZGxnfffefo6MidJDWbjz7CvHnQas3ZJzEJeogIsbmZ+n379gGIi4sTiUQAqquru3XrNnbs2LZt25pzGF26YPRobN5szj6JSVCMEps7N+rj4wOgoqKCezt06NDs7GyNJZ5Jv2gRQkLg62v+nokx0UE9sbmD+lGjRgFYvnz5lStXuC1CoZCrTM2Dx0PnzgDg5IT330fXrmbrmZgExSixuWp01KhRkyZNUqlU8+bNM3/v1dUYMQIODqipAYDRoyGTmX8UxJgoRm2aWq3eunVrXl6el5eX7VSjADZs2ODu7v79998nJyebuev163HxIlJSmro+NGk+KEZtlEqlio+PDwwMnDVrllKp3LRpU4cOHSw9KPPx9/dfuXIlgDfeeMNwktQMysqwdi0ArFsHPv3ytRiM2BilUimVSg21Z79+/ZKSkvR6vaXHZW46nS4sLAzA/PnzzdbpO+8wgA0bZrYOiTnQCk82pKSkZOPGjR9//HFZWRmA8PBwiUQyduxYS4/LYrKysoKDgwH8/vvv/fv3N3V3d61tSloOS+c4MYcbN25IJBLDZHR4ePjPP/9s6UE1C9ws08CBA3U6nan7eu01BrCoKFP3Q8yNqtEWrqCg4MMPP/zPf/5TXV3N4/HGjBmzdOnSQYMGWXpczYVKperZs+eVK1c2b948e/Zs03V04QJ69QJjyM6Gue44JeZi6RwnppKXlxcbG+vg4ACAz+dHRkZmZGRYelDN0c6dOwG4urpevXrVdL08/zwD2KxZpuuBWAzFaAuUk5Mzffp0oVDIBWhUVFRubq6lB9WsjRs3DsDUqVNN1P7Jkyd79ZoxaJDclEFNLIZitEU5ffr09OnTBQIBAHt7++nTp1+4cMHSg7ICBQUFLi4uAH744QdTtP/000/j1gqnpOWhGG0hTpw4MXr0aO5EjZOTU2xsbGFhoaUHZU3Wrl0LoHPnzlVVVcZt+ccffwTg4eEhl8uN2zJpJmiKqSUoLi5euXLlpk2bXFxcoqOjJRJJQECApQdlZbRa7cCBA0+fPr106dK7Fm/ev3//lStXdDpdeXm5Xq9XKpWMMe6iMYVCAUCpVOr1+vLycp1Op1KpMjMznZ2duZ9ljIWEhGRmZq5bt27+/Pnm/1zEHCwc48QYEhMTAfTr14/qnaY4efIkn8+3t7c/e/Zs/e2Pe0lpSUmJ4We//vprAK1bt66srDT7ByJmQgvltQTc2iLDhw+3qfvijS40NHTmzJkymWz27NlHjhzh8Xjc9rFjxw4cOJDP57u5ufF4PHd3dwAeHh4A3Nzc+Hy+q6urQCAQi8VCodDFxYXbAUBtbe2yZcsArFy50pwrSBEzoxhtCWxtpTvTiY+P37t3b2pqamJi4iuvvMJtXLFiReNa27p168WLF7t16/bSSy8ZbYik+aEYbQlsbaU703Fzc1u3bt20adPmz58/ZswYboHn+zKcCdVqtRUVFbW1tZWVlRqNpqqqSq1W19TUlJWVLV++HIBUKuUuPiMtFf3fbQmoGjWiF198cdu2bSkpKSEhIZ07d37QhFJDmurfv/+AAQPGjx9v2hETS6MYbQmoGjWuSZMmpaWlXb58+fLlyw/ax3Am1M7OztnZ2d7eXiQSOTg4ODo6Ojk5OTg4iESisLCwGTNmmHPkxCIoRlsCW3tCsknpdLr169dXVlbOnTt34sSJ9SeU3N3deTweN6Fk6WGSZoRitCWwtUd7mtSXX3559uzZ9u3bf/DBB9yKBIQ8HC3A3RJQNWosGo2GWxV/1apVlKGkgagatXqM1f76q79W25W7K5w0xcaNG/Pz84OCgl588UVLj4VYDYpRq6fVyhn7y9HRz3C5OGkc7vlUAKRSKZ+elEQajP6uWD2tVg5AIKAj+qaKj48vLi4eOnToc889Z+mxEGtCMWr1dLpSAEIhzS81SXFx8fr16wFIpVJLj4VYGYpRq8dVo0IhVaNNsnz5cpVKNWHChCFDhlh6LMTKUIxaPa22FIBAQNVo4+Xn5//3v/8VCASrV6+29FiI9aEYtXo6HVWjTbVo0SKNRvPyyy/36tXL0mMh1odi1Opx1SidG220M2fO7Nixw9HRMS4uztJjIVaJLniyHK0W+/ahoAC9eiEiognNcDFK1WgjvfPOO3q9/vXXXw8MDLT0WIhVooeIWIhOh2efxRNPICQE+/ZBp4NEgv374eaGl19+rJZKSj5VqQ55e88Wi4eZaLAt2JEjR4YPH+7m5paXl0e3gZHGoWrUQvbuRbt2WL4cACIjMXgw1GrMmIHHvOq7puZcefnPWu3NiopfKUYfF2Ns4cKFACQSCWUoaTSKUQs5exbBwbffhoQgJwdDh8LLC56ed3z19KwYE6D3dhYIvIRCT6HQWyBwM/xcQUFMmzbrRKJgjeaBS7o9Wm0t8vPh7w9X1yZ8JOuzc+fOEydOtGrVKjY21tJjIVaMYtRCxGJUVNx+W1EBxqBQQKG4d9+rg/tUKLIMb3k8ARep3t4xPJ6guvqss3Oog0MntfpiVdUfQqH3rcD15PMbcJf9Dz8gLg5hYfjzT/TqhQ8/xN9/A0CHDmjRa7brdDruQUlxcXGGB3kS0gh0btRCcnLw2ms4ehT29lAoMHgwTpyAXg+5HKWldV9vvbgyV1styNfpSrXaEq22VKdTcm0EBKzy9JxSVLSsqiqzVatlOp3q8uV/1u+Ex3MQCj0dBO27zbG7o8jl/vP0RI8eGDoUJ07AwwMAoqLwj39AowGAyEg4Od137Evy86+p1Y58PoAVHTr42NmZ8k/KVLZu3Tpr1qwuXbqcPXvWzjo/AmkmWnK50az17o0ZM/Dkk+jYEXl5+OgjcI+TvN+aoW3ufMuYVqcr1WrlAoGnnZ1fhw7faLU3c3P7tmv3iYdHlFYr576r1Zbq9ZW1tdcEOicc/fv+w/j2W/ToUZehAMaPx/HjeNTdkBq9fmG7dl0fELJWobq6mnsY/Zo1ayhDSRNRjFrOrFmIiYFCcd/ofAgeTygU+gqFvgCqqjKcnPozpuHx7Fxdn3Nzm1B/T8bUWq1cX6nAryW3y9uSeq9dXFB/IXc7u7pS9FFyKioUtbUigSDIeg6HlUrlxYsX8/Ly8vLykpOTr1y5MmDAgEmTJll6XMTqUYxaFI/3uBl6F6Xyh6KiZYCgffvPeDz7e5p3sLMLgHsAHjSHX1aGt95CbS24iuzYMYSFNaTfv2tqlDqdl1DYPGNUoVD8fT/19/Hy8ho0aBCtLkiajs6NWrfKyvQrV+aLxU8GBKxqZBMJCUhJQVQUzp7FmTPYv/+RM0sL8vJmBgQ0h4N6rVZbWFiYl5dnKDM5lZWV9+4sEok63VJdXf3JJ5/4+/v//fffTs3ggxCrRtWoddNoCioqjtrZPfBx6o/25pt49lmcOoUxYyCVwhoe1paRkfHuu+/m5eVdunSptrb23h28vLw63alz586tWrWqv096enp6evpnn302d+5ccw2ctExUjVq3mzdlly/P9vaOaddOZrZOfykr6+vi4mWhy6FOnDixbNmylJQU7q2Hh0fHenr27Nm7d2/ucZ4Pt2vXrueff75t27YXL160t7/7fAghDUfVqHWzyJrNA1xcRp4509bR8XtLrIf022+/paSkPPfcc2vXru3UqZOjo+PD91coFPWP91944QVucfsJEyYEBQVlZ2d/+eWXr776qlnGTlomilHrZpF1SZRaLQMsNTWTnZ0NYNy4cfcuateQmSV/f38uRnk83qJFi1588cV///vfL7/8srBF32tATIr+6li3Ww9iMms1qtRqAbhZ6CwqF6NBQUHc24yMjDVr1nCVZlVV1b37Ozs71z9DOnjwYMO3Jk+evGLFivPnz3/77bfTpk0zz/hJy0Mxat1uHdSbtxrV6QC4WaJ802q1ubm5PB6vd+/e3Ba1Wr17927u9V3nSTnt27d/0GM+BQKBRCKJjo5es2bN1KlT6WmgpHEoRq1baWk3YLBO1+bRuxoPV426WiJGL1y4UFNT07FjR9dbq6j06dMnKSmJKzbd3Nwe/uP3+sc//rFq1apz587t2rXrhRdeMPZ4iU2gf36t2yuvxIeGpt24EfzoXY2n7qDeEjGalZUFoE+fPoYtYrE4KipqwIABjchQAHZ2dgsWLACwevVqumqFNA7FqHWTy4H734hvQnUH9ZY4N8qdGK0fo00XHR3dunXr06dP79+/34jNEttBMWrduHX1zByj5ZauRg3zS0bh4ODw9ttvA+AWKyHkcVGMWjGVChoNxGKY+eJxC54bFQrn9O8/Pyion3GbnTVrlq+v78mTJw8dOmTcloktoBi1YhY5ogegPXq0S26ua1mZmftVKrFnz+g//1zXuXNn47YsEonefPNNAGvWrDFuy8QWUIxasdJSADD/M4QOrV+//aWX7O+3UL9JZWWBMfTubZL7/ufOnevh4XH48OFjx44Zv3XSolGMWjFLVaNyuRyA+Z8Bl5UFAEadXrrN1dWVeyLTe++9Z5IOSMtFMWodLl6EXl/3urAQlZX44w8EB+PIEaxejbNnzTqY0tJSAJ5mz+/sbAAw6vTSHWJjY8Vi8Y8//pienm6qPkhLRDFqHSZNgkpV93rBAmRmIiQEO3bgyScREoKoKPONRKPRVFRU2NnZubg04Hl5RsVVo6aLUU9Pzzlz5oAKUvKYKEatVe/e+M9/cOOGufs1HNGbed14xuqKbtPFKIB//etfIpFoz5493JVVhDQExajV2LQJH36IDz/E+fMA4OCApUsxf765h8Ed0Zv/xGh+PsrLERAAnyYsUX0vvV4fGxt78OBB7q2vr+/MmTMZY8uWLdPpdMbsibRcFKNWo3t39OyJnj1huOlxwgQoFDhyxKzD4KpR858YNcX8kk6ni46O3rBhw7Rp01S3TpqMHz/ezs4uLS3Nz89v8uTJW7duvXbtmjF7JS0OxajVGDECo0Zh1Cj4+9/e+PHHWLwYAE6exKefwgw3hVuqGpXLIRbj1rpORqDVal955ZXExERnZ+ft27eLxWIAGRkZkyZNqq2tra2tlcvlO3bsmDVrVtu2bYcMGbJ69erMzEy6757cByPWoG9fVlZW93rKFHb0KAsOrnu7fDnr3p1168YANno0u3LFhMPIzMwMDw93d3fv0KHD1atXTdhTPbt3s6NHGWNMr2c7drCiIiO0qVarJ06cCMDNze23337jNh47doxb3yQyMrK6uvrChQsfffTRyJEjHRwcDL8v/v7+b7+9eceO2/87CKEYtQ7p6UyrrXt99iwrK2MnT9a9ra5maWksKYl5ezOAubkxmcz4Azh8+HBERAQXJc7OzgA8PDy++uor4/d0j8mTWceOTKFgjLFp025/8EarrKx85plnuI9w8lZzv/76K1eQTpkyRaPR1N+/qqoqJSUlNjY2MDAQwLBhhwEmELDgYBYXxzIymF5/e+erV1lhYd3roiImlzd1tKT5oxhtOa5fZxMmMIAB7LnnmLGKxdTU1BEjRnABKhaLY2Njs7Kyxo8fz20ZM2aMqcvSyZPZkiVszhzGjBGjFRUV3Mfx8/M7c+YMt3H//v3cY5anTZtWW1v7kB/PysrasEE+bBgTCuv+qAHWrh2bPZslJ7PKSrZ0KQsMZCoVY4wtX87M8g8NsTCK0ZYmKYl5ejKA+fiw775rfDt6vT45OXnQoEFcXHp5ecXFxZWWltbrKMnDwwOAj4/Pd03p6VEmT2bZ2eypp9jJk02NUYVCwT1EpFWrVjk5OdzG5ORk7rB91qxZOp2uwU2xpCT2yivMz+92njo5sbffZhMnsvnzGaMYtRkUoy1QQQGLiKj7xZ49u1z+mAeWOp0uOTk5OLhuKWgfH5+4uLiy+50LLCgoMBzpR0VFlZSUGOkTMMaYXs927WLfflsXozk5bMgQNnUqO3mSffMNu/Owu0FKS0tDQ0MBtGvX7uLFi9zGb775xs7ODsD8+fP19Q/OH0dODpNKWUQECw5mS5eynTtZeDg7c4Zi1FZQjLZMej2TyZirK+vbN9bPz2/37t0N+SmdTpeUlNS9e3cuGdu2bZuQkFBVVWXY4fTp0zdv3ryzI71MJuPuaPL399+zZ0/TB6/TseRkNmAAA1irVuyFF1h2NmOMLVjAPDxYfDwDWGAgk8luny9+pOvXr3OrlHbt2rXw1snLL7/8UiAQAJBIJE0fNmNMrWZLl7Lvv2d//MGefJJi1FZQjLZkeXmlTzzxBJeJr776qlKpfNCearU6MTGxS5cu3M7t27dPSEiorq427HDq1KmoqCgej7dw4cJ7f/zvv/8eNmyYoSytf+z/WDQa9vnnrGvXulI6MJBt3Mhefpnl5jLGmErFundnmzezHj3qdujfnx048OhmL1++zH20Hj16GM7kbt68mXuG3YoVKxo32vviYpQx9vrrLCiIYtQmUIy2cFy1KBKJAAQGBv7888937VBTUyOTydq0qXsoXqdOnWQyWf1plqNHj3Lz2twc/bvvvvvIjtq1a3fo0KHHGqdazRITWefOdfnYoQNLSGD1YvwOOh1LSmIdOtTtPGQIS019YMv5+fmdOnUC0L9/f0MpvXbtWgA8Hu+jjz56rHE+kiFGlUoWEEAxahMoRm1Cbm7uwIEDueCIiYlRqVSMMZVKlZCQ0KpVKy4ig4KCEhMTtfWOk1NTUyMjI7nvuri4xMbGFj3qos2zZ8/e29HDVVZWbt2aGhBQl4k9e7KvvmrQ0bpazWQy5utb94MRESwr6z67paamikSiwYMHK7hrphiTSqXcCDdu3Pjobh7T1at112YVFrJPP6ULnmwCxaitqK2tXbVqlb29PYCOHTu++uqrhhs6Bw0alJycXH+CJSUlJSwsjPuuq6urRCJp+DxVbW2tVCrlOurQocORI0cetKchxwUC+/btNX36sMTExzjdeasRJpUysZgB7KmnDkZFReXn59+1z/Hjxw2BvnTpUgACgWDbtm2P19PjqK5mDg6Mz2eNPb1BrAnFqG3Jzs4eMGCA4RL68PDw5ORkw3e5OfqQkJBHztE/UlZWVv/+/QHw+fzY2Niampr635XL5XFxcdz1UgDCwsIOHsxp7Dw5Y4xdvcreeEMjFvsBEIlECxcuNNSeBnq9ft68eQDs7e137NjR+M4a5oknGMD27jV1P8TyKEZtjlqt5u6IT0pKMmzk5uh79OjB5Zqfn59UKq2srGxKRxqNRiqVcpcT9ezZMz09nTFWXFwcFxfn7u7OdXRXjjfR+fPnuXkw7g4lqVRquMxAq9VGR0cDcHBw2LVrl7F6fIglSxhQdwEpadkoRm0RV4oajnMVCkXHjh25XOvQocOWLVvuKh6b4vjx4926dQNgZ2cXHh7OzUEBGDVq1LFjx4zVS32///674bar1q1by2Sympqal156iStUf/rpJ1N0yklPZ//+d939Yz/9xAAWEmK63khzQTFqc9RqNXdgW3/js88+27Fjx7vm6I2lurpaIpHweLzWrVvzeLzIyMiTTb8x/lEOHjzInb4AwC044urqmvqQGX1jGDuWASwxkTHGKiuZvT0TCGgRk5aPYtTmFBUVcXdD1t9YXFzc8PsgGyc8PByAKSbHH0Sv1yclJXXq1KlNmzZisfj48eOm7vH99xnAoqPr3g4ezAC2f7+puyUWRuuN2pz7rrvs4+PDXYtuOlqtFoDhHlMz4PF4UVFRp0+fLikpqaioMPrT7e81fDiA2wtpc3ckmHldbWJ+FKM2x2zrLufm5u7cufM898wTyz1P1MXFJSwsjDFmhgfQ9+sHd3fk5aGwEKAYtRkUozbHbE8B2bNnz6RJkxITE+v3a/5l8wFwN6oeMX2eCQQYMgQAUlMBIDwc9vZQKmsqKqpN3TWxIIpRm2O2OKtffur1+rKyMj6fb7jUyZzMFqMAhg0Dn4/MTBUAsRhDhow/d84pLS3VDF0TS6EYtTlmO7iuX/aWlZXp9Xp3d3duRSUzGzx4sKOj45kzZ8rKykzd19NP54nF7fftG8i9DQnpCuDo0aOm7pdYEMWozTHbudH6Za+lnifKcXR0DAkJ0ev1Zjk92k6vLz1//jx3RQRXCP/666+m7pdYEMWozTFbotUvey14YpQzfPhwmOW4XigUcgvsc5E9dOhQgUCQnp5eVVVl6q6JpVCM2hyLVKOWmqY3MGdVWP9UrJubW9++fTUazYkTJ8zQNbEIilGbY+ZqtP5BvQWr0SFDhtjb2586dUqpVJq6r7tmtMw5wUUsgmLU5pgt0RQKBQBuGSeLV6MikSg4OFin06WlpZm6r4EDBzo7O+fm5hYXF4Ni1AZQjNoc8yRaeXm5RqMRi8XcwqNmO5PwEGaLM3t7+/fee2/79u3cEjBDhw7l8/knTpyoqakxddfEIihGbY55YvSu3LTsTD3HnFVhbGzs5MmTuRj19PQMCAjQ6XTjxo3btm3bjRs3zDAAYk5CSw+AmFVlZWVNTY1IJHJycjJpR3flZnOoRp944gmhUJiRkaFSqcRisXk6ZYy9+eabV65ccXV1TUlJSUlJAdCzZ8+xY8dGREQMHz5cKKTfQatH1ahtMfO1982qGnVxcenfv79WqzXbpDlj7I033li/fr29vX18fPymTZvGjBkjEolyc3Pj4+NHjhwZEBAwffr0b77ZXlpqnhERk6AYtS0WuRPUnP0+nDmP63U63YwZMzZt2iQSifbu3Tt79uw5c+bs27dPLpenpKRIJJIePXrcvHnzq6++Wr78e19fhIRg4UIcOwbGzDA6YkwUo7blvgfX3ISycd2VmxafqeeYLUY1Gs3//d//JSYmOjs779271/CEagCOjo4RERFSqTQ3N/fPP//88MMPhw+fKxTijz8QH4+hQ9GmDWbOxPffQ6UCgF9+QUhI3eujR7FiBd58E2fO1LW2fj127TL1pyGPQDFqW+49uL506VKXLl1mzZpVUVFhxI6aZzXK3VP0+++/m/SeIrVaPWXKlO+++87d3T0lJeXpp59+0J7dunV76623ZLJhJSXYtQszZ6JNGxQV4dNP8cIL8PbGiBHIzoZKhbg4AKiqglyO68dkHSIAAAcBSURBVNdhmPMvLUV5uek+CmkQilHbwqUb99A3TlpaWnV19datWwcMGGDEayqHDh26ZMkSrvrTarUqlUooFLq6uhqr/ca57z1FhYWFYWFhK1euzMjI0Ov1Teyiqqpq7Nixu3fv9vT0/Omnn7gbQx/JxQUTJmDrVhQWIi8PCQmIiABj+OUXiESYMAGnTuHUqdv7X7uG/Hzk58P0a62QBrDw6vvEvM6fPz9q1CiBQCCRSDQaDbcxOzvb8DDkmJiYJj4Q9F7cJT6+vr7GbbZx3nrrLQDLli0zbNmyZYvh18Hb2zsqKioxMbG0UQ+YV6lUTz31FAA/P7+srKwmDrW0lCUns+RkJpGw06dZeDjbv5+98QabMoVNmMBiYlhMDAsOZtu2NbEf0lQUozYnNjaWq0ZDQ0Nzc3O5jfd9GLKx5ObmAujevbsR22y03bt3Axg2bJhhS1VVFTfnwz3BlCMQCIKDg+Pi4rgStSEtKxSKsLAwAG3btr1w4YKxBszFKGPszTfZ1Kl1MXriRN134+IoRi2PYtQWpaamdurUCYCjo6NUKtVqtdz2kydPdu/eHYBQKJRIJGq12ijdffDBBwC6du1q6qfmNYRcLufz+XZ2dkePHr13PHl5eQkJCREREdzNVxw/P7/p06cnJSUplcoHNXvjxo2+ffsCaN++/cWLF404YEOMKpWsdev7x+i337ING5jxnopNHg/FqI1SKpUxMTFcWTp48ODz589z27mHIXOLKwcFBWVmZja6C71en5ycHBoailt31g8ZMsSIZVqjLVmyJDAwEICXl1dUVJRMJrt27dpd+yiVyu+++y46OrpVq1aGPHVwcBg5cuSVK1fu2vnatWu9e/cG0K1bt8LCQuOONjf39rNFf/6Z7dnDtm1jly7VbfnxR3bwIDt+nO3dy/77X+P2TBqKYtSmHThwoE2bNgCcnJykUqmhOvvtt9+6dOkCwM7OLi4uzlCuNpBWq/3mm2+CgoK49PH394+Ojvbz8wPg4uKyefPmBh4mm4hOp3v99dc7duxY/xA+PDx8zZo1mZmZ944tJydHKpVGRETY2dmJxeK7ivSCggLuz6pnz55FRUVm/Bx3+PRT9ssvlurc1lGM2jqFQhETE8OlSUREREFBAbe9srJSIpFwT10eNGjQuXPnGtKaRqNJTEzkzgwACAwMTEhIqKqququjkSNHXr582YSfqmHy8vJkMllkZKSDg4MhUn19fblDeIVCcdf+JSUlR44cqb8lPz+fi+MBAwbcvHnTjGO/w4ED7JNPLNU5oRgljDHG9u3bxx29urq6ymQyw/aDBw9y5apIJNq3b99DWlCr1YmJiVxdxp0iTEhIqK6uvmu3HTt2+Pj43NuRZVVWVqakpMTGxrZt2/auElUqlT5oluncuXOtW7cGEB4eXlZWZv5hc86cYc88wyQS9uOPlhqCraMYJXVu3Ljx/PPPcwkyatQowxlA7iyqt7f39evX7/uDNTU1MpmMS1sAnTp1kslktbW1D+ro+vXr48eP53YeO3bstQc0ayn3nWVq3759TExMUlJSeXk5t1tOTg73D8+wYcMMG4ltohgld0hKSuLuNXJ3d69fLd43Q1UqVUJCgmESJigoKDExsYEnUpOSkjw9PT0CAp4/fXqn5Q6HH6K0tHT79u0vvfSSr6+vIU+dnJxGjRr1zjvvcDdojR49mjtlQWwZxSi527Vr18aNG8elxqRJk+57yk+pVEqlUsO9nv37909KSnrciaPCwsJ3U1ODMzKCMzIW5uWVPbiAtTjDLBO3rh2fz7e3t3/++eeNdU0YsWo8RuvJkPv54osvXn/9dZVK5evru2XLlokTJ3Lbb968uWnTpo8//ph75nt4eLhEIhk7dmyjO/pBLo8vLKzS6TyFwkXt2j3l7m6cD2AaxcXFBw4c+OuvvyIjI4ODg2m1UAKAYpQ8UEFBQXR09C+//AIgKipq1apVn3/++YYNG7h1PcLDw1esWDFixIimd3RNo1lx6VKGSgUgwsNjcWCgK8UTsR4Uo+Rh9Hr9xo0bFy1aVFVV5ejoWFNTw+Pxxo0bt3Tp0pCQECN2xIBdJSUfFRZW6/XednZL2rXrIRJdVqu577ZzcPCyszNid4QYEcUoebQLFy7MmzevR48e165dW7x4seG6eqMrqKlZfulSdmUlDxjv41OsVge5uAAY6ubWXSQyUaeENBHFKGle9MC3xcV75fJILy8w9qKfn6VHRMgjUIyS5kjH2M6Skp8VCq4InRMQ4MintXFJM0Un8klzJODxAPQSiUZ7egKwr7fONCHNDcUoab587Oy60ilR0uzRgRIhhDQJnRslzZRSq2WAO11ASpo9ilFCCGkSOqgnhJAmoRglhJAmoRglhJAmoRglhJAmoRglhJAm+X8U1V9jMIYuMgAAAjB6VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHu/b+09BiDgAWJGBgiQB2IlIG5gZEvQANLMLGwJFiCakQUhAKUVDJBoJgSNrg7TIFwmYlGBoRRdhlNBAeR+KMWuABFmZodoQNAQCSYMCQ4FkH//M8JoAQWQOCsLNwNHAoNgBhODuAIjUwYTo3gCE3MCE68CM2cGE7NEAgsrAysbA5scAztHBhO7cAK7mAKHCAMnVwKneAIXdwYTN08Cj0QGE4+kAi9fBhOvQAKfVAK/VAYTv3SCgHQGk6BQgqAog5BwBpOYHIOMHIOsHIMICysjEzOnOBu7sJAgAwcbFzePBDMnG58Uv7QArzgsghjkG6S793eYX9gP4nhwstvf/c1gD2Jz32FwaM81BbNzt2s5RKqpgNXYzvI/MLt0ogOI/bYn7MAqbWcw+3PFtAMeAZJgNkNq9oEfqjvA6tkZRA+k3/MAs6N+nLIXFbsOZvO++2Hfd8DjAIituDbCYW5JMpht+KXPQfOzApi9RU3PIYyBCWI+T7tDjyQrmM0c1+KgsHQqmB3255u9WE8wmP2QYeb+wNvuYL2ZT5UObN5WCGZvCC860HHJGswO5+U7cFreDOyvzaU2ttX7a8Hii7PnHnDbLQF226GdbXYdjJVg9pGyZgfv6nYw245/r4PFcog5HpvmOjTsiwTbe+WEhkOrxBQwm0s15IBmhRfYfMFLJw9cZ2sEs70/zTzwxikNzBYDAFHjlN45N0kPAAACMnpUWHRNT0wgcmRraXQgMjAyMC4wOS4xAAB4nJ1WS27cMAzd+xS6wAgkRVHissj0AxRJgBToHbrqprl/qc/IHiQBYg4MDJ9pPvMvy+vr3/hlC+33cv35519YP7puW0gYEocA716qGn4TADT7C0aoUockJKVxQDQthIfwEcXx2oZFppKnBKn6WCgCNr+bbYHq9IWiSGksF4jCSC6WS4rEIw6OmbN4WVKmHlGKwJp9LGzZoDRiS5qdLClKqTAqbaH5snsxD6jiyG6p7MtLwJhrLrPrKrCXRZnriA2TOLvOalR7fY0lZwYfC0eWkkaGMrJ7AgohzllImLy+EMHsFyjqnCNuOc1DkiL+GpHKzDNkH4t1CWpOs9JEvuy2yvCNpRRnvzTbKjL4NLF7jgh1Tk9BPObl25m9CywwvFK567rPs9h+UdS5MbPKcaafzvhCkuZm0ELFx2JdB5VGzcGWhI8lR4WxpVqNCL2+KPWNab3LcwOfZ7HzKPXN0OZo8p1maSfJ2ipFQQ8sz29Z8AMWsRkUHXMJcOfLCRaO1Yo0bKvenWq/3rK88yGydW4db+gAjY5uoJ2YU2P30tLQUZM68wK4Aw4Iy4YD5aUxSRYwqSxQ2jfTDdTuG90AwUHTumACDbRs7I14BLujdrt9gww2k3ARmNR8owWWbxYM7hoDy1G7TTuQDmiBujSlg6mpAVeuDRAtoD248ZhFtueA9AAS7OAxhIcf37uNPWNTGpra/pvm69N1+w9/eaUC90aVpwAAAXh6VFh0U01JTEVTIHJka2l0IDIwMjAuMDkuMQAAeJwlkjtuIzEQRK+yoQRQRP8/cCjAoTfY0HA0uU7gw281hQGImQJfdbE4z+fz3+377+Pn/l6/Lr5un/fr9njJhfXS64VH73iBcN2+7i98zJaL//zeHrrFNHvZdvPg9QFFXdSXbrJ2g2I7SSSWbG13OUoxlS7a1W3eb4wtA1I2VQek2EpRvXgTFb255tZeD9reEVQHjCyy9eBtWjEgBkmxzrYsC7OjCbcff2YThQTfAjtkSARS0JZQ1hiyU6JGckkrB+ikZQBlE6tN+qRKOkoKM+OEpCy5PmyLkOoI2WOD5FLEaMXQhY+AOVYoLjKMxyMUI0eQbIRhIO0FRMnfcyPSfMKBEJ4tXp7nAEWIPYxNi2gF9ok5oMtnj253HV/bFqm8UImzFcrxjcr5KK1CJy7uBzGnIy/MnLbQn9qxFsEMVEMWxHTMG4fh0zN+hCF1Z067c0M593LcLWXdf/8DMjWCK33TS9MAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f1aa26729e0>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f0bdd139490>"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10831,17 +11092,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAWsUlEQVR4nO3deVRTZ94H8N9NQgAJFAlCJBbFHUSW41KRpUgHX6tjFfpq3aqOC7x0ps44OopDrbbqWKxtX6WnL2Brl7Eq6HEZtTotRS0gKogoglQKFCIEESqELQvJff9ISzutRCQhucHv5y9P7uPN757D+Z5nuXkehmVZAgCA3uJZugAAAOuGGAUAMApiFADAKIhRAACjIEYBAIyCGAVza2pqmj9/fnV1taULATANxCiY28aNG48cORISEnL79m1L1wJgAgzeGwUza21tjYqKysjIGDhw4JkzZ4KCgixdEYBR0BsFcxOJRKdPn46Ojn7w4EFkZOSXX35p6YoAjIIYBQuwtbVNT09fsWJFW1vb7Nmz09PTLV0RQO8hRsEy+Hz+hx9+uH79erVavWjRotTUVEtXBNBL/K1bt1q6BnhCMQwzffp0e3v7r7766syZMyzLhoeHW7oogMeGJSawvOTk5D/+8Y86nW7NmjXvvfcej4dBElgTxChwwvHjxxctWqRUKl9++eX9+/cLBAJLVwTQU4hR4IrMzMy5c+e2tLTMnj07LS3N3t7e0hUB9AhiFDgkLy9v5syZDQ0Nzz777L/+9S8nJydLVwTwaJiEAg6ZNGnS+fPnPTw8Ll68uGrVKkuXA9AjiFHgFl9f35ycHLFYrFAoamtrLV0OwKNhUA+co1KpHB0ddTqdQqEYMGCApcsBeAT0RoFzbt26pdFoRo8ejQwFq4AYBc4pLCwkosDAQEsXAtAjiFHgHH2M+vv7W7oQgB5BjALn6GM0ICDA0oUA9AiWmIBbWJZ1dnZWKBR1dXXu7u6WLgfg0dAbBW4pLy9XKBQeHh7IULAWiFHgFozoweogRoFbbty4QYhRsCqIUeAW9EbB6iBGgVsQo2B1sFIPHNLY2Ojq6ioSiZqbm7F5M1gL/KUChxQUFBCRv78/MhSsCP5YgUP0I/px48ZZuhCAx4AYBQ4JDg4eP378F198oc9TAKuAuVHgkJaWluDg4KKiIjs7u3fffTcuLs409y0tpQMHaOBAcnenESNo5EgaNMg0dwZAbxQ4xdHR8erVq2vWrFEqla+88kp0dPSDBw+MvalaTSkptGULrVtHly9TUBAyFEwLMQrcYmdnt2fPnmPHjg0cOPD48eMBAQG5ubm9v92JEzR2LCkUpisQ4NcwqAeOqqqqWrhwYW5urkAgSEhIeP311x9v+V6tpr/9jfbuJSJ69VUaMIBcXMjDg5Ys6aOC4YmF08CBo4YOHfrNN99s375927Ztzc1flJfnDhv2mY1Nz/YruXuXXnqJLl0iW1tKTKQ//7mPi4UnGnqjwHVnzpwaMuQvnZ0VQuHTXl4HRaIQw+3b6jMHBCxi5Pdo6FA6coQmTTJPnfDEQoyCFVCrZZWVi1pbsxmGL5G85uHxejfT+mxd3a7a2gRJWahHKo8OHSI3N3PXCk8exChYB5btlMu3y+XbiHSOjtO8vD63sRn8ywadnY2VlUsUinMMwx8s2TpY8nfCT6HALBCjYE1aWjIrK5doNHKBwM3L6zMnp//Sf97efq2iYp5KVSkQuHp5Hej6HMAMEKNgZTQaeWXl4paW8zY2g319y3k8eyK6cye8peWig0PQ8OHpQuEQS9cITxbEKFgfltXW1e1wcAjq7LynUlXx+Q7Ozv99//4HHh5vMIyNpauDJw5iFKxYXd1bAoGLk9MModDT0rXAkwsxCtZNpaqUy7dKpYk2NhJL1wJPKLx+D1bs/v3/02oVOp2SzxdZuhZ4cqE3ClZLo6n/5Pn7km+UHhp///sCgaulC4InFF6sA6tlY+MWddhRMYKIlMrblq4GnlyIUbBmrq664Mn0mDF68ODB1157zcXFxd7enmGYuXPn9ll98ETA3ChYp592Yh5op2ycQh0dPYpRjUazfv36vXv3SiSSrp1Mz5w5U1paOnbs2L4sF/oz9EbBOv20E7Pt9XbHW173btk/8n/cv39/xowZe/futbW1Xb9+/ZQpU/Sfz5o1a8yYMX1cLvRn6I2CdVMqh45ZfsrTk6qqDDXLycmZP39+bW2tVCo9evTohAkTtm3bpr+0Z88ehmHMUSv0U+iNgnVavZo2b6Zdu5ymT7G1JZmMWlu7bZuamhoREVFbWxsWFpafnz9lypQ//elPzc3NHh4eMpls6NChZqwb+iMWwMr5+rJEbH7+Qy51dHSsWLFC/6ceExOjVqtZln377beJyN7e/urVq+auFfoj9EbB6nl7ExHd/s0ik0wmCwsL279/v0gkSktLS0lJsbGxOXfuXHx8PMMwH3/88STs6AymgLlRsHq/+x0JhTTkP/d1On/+/IIFC+rr60eNGnXs2DFfX18iKikpWbBggVar3b59+0svvWSZcqHfQW8UrJ5CQV5eFB5Or71GRMSybGJiYmRkZH19vf5AJ32GNjY2vvDCC62dnVErVjy9cuU+ufxkQ4OFS4d+Ab1R6A9Ylu7eJaWS3NxIp3NrbGzg8XiOjo5VVVXvvvvurl276uvrV65cWV5ePv6ddwbMmMEwDJ9lB9pgVz0wAcQo9AdxcZScTJ2d1Nio1ekaRowYIZPJWlpaQkND161bV1BQEBUVJZPJbGxsfN3dHQQCIooeNMhZgL9/MAEM6qE/cHAgT0+qrKwkkjIMU15erlarY2Jivv766/Pnz4eGhlZXVwcFBd25c+fg4sUpo0dbul7oV7DDE/QTZWVlkyZNam5uJiKBQJCcnLx8+fKEhITExEQiiomJSUpKEgqFli4T+iH0RsHq7d5NVVVtzz//fHPzZv0nDMMEBATMnDkzMTFRIBC89dZbKSkpyFDoI5gbAqvHsuyzzx6sqppNZMvj8XQ6XUJCwpIlS0pLS11dXdPT06dNm2bpGqE/w6AerN7MmZlnz77EMI0Cwf9qNH+eNm1aQUFBc3NzQEDAiRMn8FtP6GsY1IN1y8jI+Pe//83j8caPH6/RaDw8PC5evNjc3LxgwYKcnBxkKJgBYhRMZvdu2ryZiOivf6XycnN8Y1VV1YIFC3S6XaGh3jdv3hQK/15bW8swzFtvvXXo0KEBAwaYowh44mFuFExJ/xp8cTGNHEkuLjRvXpGra9rEiRNDQkJcXU18VtKtW7diY2MfPHjg4OAgk8kYhlGr1S4uLocPH46MjDTtdwEYgBgFU9K/Bq/Tkbs73btHt27l5uTsIKIdO3YsW7ZMKpWa6osOHTq0evXqtrY2W1vbtra2iooKqVQqEolOnjyJPZjBzDCoB9M4coQKC8nGhjw9ydeX6uqoupo2bhy7adMmT0/PhISEzz77zCRf1NnZGR8fv2jRora2tsWLF9fW1uo3apJIJHl5echQsACLbtMH/YROx44axRKxp08/5OqhQ4eIaObMmcZ/kby+PiQkhIiEQuEHH3zAsuyrr75KRBKJRCaTGX9/gF7AoB5MICODysro6adpxoyfP2xqarpw4QKfzw8NDSWinJwcrVbL5/N7/S2Fra2b6+pUEolUKj1y5EhQUNDnn9fv359ua2t7/PjxIb/aKQ/AXDCoBxNITiYiio0luZyee46OHSMiunLlSlRU1M6dO6VS6bBhw5qbm4uLi3t+z/fff3/Tpk1Lly5tbW0lokP19f9z545crQ7durWgoCAoKOjSJVq50m3w4O/37TvUdT4dgPmhNwrGksvp1CkSCOgPf6CUFMrMJHd3io6moKAgPp+fn5/f3t4eGhr6/fffZ2Vl+fn59eSeeXl5a9asISKWZa9evx758ae5DEtE0a6uGzw9BQwjl9P8+aRS0axZdi+/HNW3TwhgEHqjYKz09IujR7fNnUtubvTRR0REsbFERE5OTv7+/hqN5urVq/oJzezs7B7eMz4+nmXZVatWBU6aZLN5Sy7D8jv5O4cN//vQoQKGUalozhyqqaGICNq9u6+eC6CHEKNgFK1W+847LxcXi1555fK5czVNTay3N4WF/Xi1Kz3106NZWVk9ueeJEycyMzO9YmPzJZKZb7zhT2OU1XZFi8a8OXegQkFEJBTSiy/S8OF0+DBhy1CwOMQoGOX06dMymWzkyJHh4c8kJa3g8Z5ety6v69T3rvQcO3asm5tbTU1NZWWl4Rt2dnYmJCQQkbu7e11NzdXMzM/mj9/1lLdYbS8WU2oqbd5MDEMtLVRURIMG9fHjAfQAYhSMkpKSQkRxcXEVFRUZGRmdnT9ER4/suqqP0UuXLmm12qlTp1IPxvUpKSklJSXDhg2rrq7+4eTJ95Yv5xHNjOAVFtL+/UQ//VCKiPBTT+AIxCj0XlVV1Zdffmlvb79s2bLk5GSdTrdw4cKBAwd2NXB3dx85cmRra+vNmzf1A3zD4/qWlpZt27YR0aBBg7Ra7dKlS8eNG6e/JBaTiwsRUVwcpaT03TMBPDZMLEHvlZaWisXisLAwsVg8derUkJCQWP3q0i+EhoZ+9913WVlZPVll2rlz571798aNG5eXlye6ffvNsrLfttGfF1JSYsLnADAKeqPQe9nZ2fpDjIkoKioqKytr8uTJv2rTNa6fMGGCSCQqLS2tr69/6N1qamr27NnDMIxWqyWi+Ph4iUTyqzYsS2vX0sSJ9N57pn8cgN5BjELveXt7E9H3339voM2sWbMuXrz4ySefCASCyZMnsyy7ffv24uJifVb+0qZNm9rb26dMmVJaWiqVSteuXfvbu509S598QjheHjgFg3roPX2MlhgcYLu5ubm5uen/zTCMp6dnUlJSUlKSSCTy9/ef8BONRvP5558LhcLq6moi2rFjx0N3C62pISIy3UZRACaAQ0Sg95RKpUgk4vF4ra2tjzwwrqyszMfHh2XZ6dOnl5SUVFVV/fKqra2tSqVat27dxIkTDx8+fOzYMR7vIUMlkYja2qi5mZycTPkgAMZAjIJRRowYUVFRUVxc7OPjY7jl4sWLDx48GBsbm5ycTETNzc1FRUU5OTnZ2dn5+fmNjY1CoTAnJ8ff37+7O/zwA4nF5OhI+pfwATgCc6NglOnT3wgP/6q8/BE729+5cyctLc3GxiY+Pl7/yVNPPRUSErJx48ZTp07J5fLIyMi2trZr164ZuIl+RI+NnIBrEKNgFCenJRcu/K6w0M1wsy1btmi12lWrVg0bNuyhDZ5//nkiyszMNHATTIwCNyFGwSje3kREt28banP79u309HShULhx48bu2jz33HNElJGRYWCWqabmI0fHIWPH/qPX1QL0BcQoGEU/I2r4Zfg33nhDp9OtXr3awHHH3t7eUqn03r17t7uPZJlM1tJS4+zc0ftyAfoAYhSM4uNDDEPffku/eQ30RyUlJUeOHLG1te2aFe1OeHg4GRzX19TUEJEJz8UDMAnEKBhFJKIhQ0ipJP3OTb8dkW/dulXfFX3kIR8RERFkMEbv3r1LRDgsBLgGLzyBsbKyyMWFxowhgYAuX6Zp02jy5HYeb5a/v//q1av9/PyEQmFZWdkj46+6unro0KHOzs4NDQ2/PLKJZdkHDx64uLj4+fkVFRUVFBQEBgb28TMBPAb0RsFYV678uH1yfDx9+y0pldTa2nHhwoXc3NwtW7bodLqYmJiedCE9PT1HjBjR1NR0/fr1rg8zMjImTpy4ZMkSQm8UuAoxCiag3wP0u+9o+XKysyOxWObv78/n848dO2ZnZ7dhw4Ye3kc/rv/666+J6PTp0xMmTIiMjCwoKLhx40ZMTIxWq5VKpc7Ozn34JACPDzEKJqDfA1SjIRcXUipJrVbcuHEjNzd3+vTpGzZs6PmikD5GT548+cwzz8yePbugoEAikYSEhDQ0NOzbt6+lpaWmpubs2bN9+SgAjw1bk4AJ6PcAbW2lkyepvZ1kstE1NV/fvXt3woQJXfsu90RERATDMIWFhTqdTiwW+/r6XrlyJTs7m8fjzZs3b/jw4YmJiampqS+88ELfPQvA48ISE3CLfh0pIiIiNze3o6ODx+O9+OKL27ZtGzNmTGNj45AhQ9RqdUVFhYFXUAHMDIN64Jbg4GCGYTIzM1Uq1fz584uKitLT08eMGUNEYrE4KipKp9Pt15/KBMANiFHgFj6fLxAIAgMDCwsL09LSfrVxVExMDBHt27evs7PTQgUC/BpiFLiloKBAo9Hs3Llz/Pjxv70aHh7u4+Mjl8u/+OIL89cG8FCIUeCQjo6Oa9eu8fn8KVOmdNdmxYoVRJSammrGugAMQYwCh1y5ckWtVvv7+z/11FPdtVm+fLmdnd3Zs2d/tX8+gKUgRoFD9KfY6w8T7Y5YLI6OjsZCE3AHYhQ45OrVm0SkP9HegK6FJo1GY46yAAzCe6PAFZ2dNGgQSSQdFy5o3N0NHVnHsqyPj09paemJEyfmzJljtgoBHgq/YgKuKCykpiZyc7N3d7c33JJhmMmTJzs4ODg4OJinNgADMKgHrsjOJiIyMKCvqak5evTovXv3iKiqquratWvt7e3mqg6gW4hR4IqsLCIiA8tLp06dmjdv3tq1a1Uq1ZUrVxiGCQ4ONlt5AN1BjAJXXLpEZLA32rWOn5eXp1QqfX19xWKxuaoD6BZiFDjhzh2qqyOJhEaO7LZNdnY2EYWGhn7zzTdEFBYWZrbyAAxAjAInjB5NJSV04EC3DSorK6urq11cXHx8fHryeimA2SBGwfJ276bNm8nbm86f77ZNVw+UZdlLly4RYhQ4AzEKnKA/hsSArh7o9evXFQrFqFGjPDw8zFQcgEGIUeAE/TEkBnT1RjExClyDGAVO0B9DIpNRR8dDrtbV1ZWVlYlEooCAAEyMAtfgV0xgeevXExHdvEn//CdNnUoMQzwerVr1cwN9DzQ4OJjP5+fk5BB6o8AliFHgioAAYll6/326dYsGD6Zly8jG5sdLZWVlPB4vNDS0uLj4/v37Q4YM8fLysmixAD/DoB64YuFCcnamW7doxAiSy+mX29snJCQ0NjbGxcXpR/ToigKnIEaBKwYMoIULiYg8PGj06I5z507/8qqzs7OLiwsmRoGDEKPAITExbEjInfb22Opql3375lZXV3ddUqlUqampX331FaE3ChyDGAUOCQhgVKol166lBgYGarXajz76iIgUCsXbb7/t5eUVGxvb0NBw9OhRb29vS1cK8DPEKHDL6tWriaitrc3Ozq6xsXHr1q1eXl4bNmyQy+V+fn6ffvrpnDlzGIaxdJkAP8Pu98Atra2tUqlUoVDMmzfvzJkz+h1Fg4ODN27c+Pvf/x4BChyEGAXOWbp0aVpamlqtZhhm1qxZmzZtmjp1qqWLAugW3hsFznF1dVWr1YGBgQcOHPDx8bF0OQCPgLlR4Jz8/HwievPNN5GhYBUwqAduUalUzs7OarW6sbHR2dnZ0uUAPBp6o8Atly9fViqVfn5+yFCwFohR4BbsgwdWBzEK3IIYBauDlXrgEI2GNJoPw8Ky8at5sCJYYgIOuXyZgoLI25tKSixdCkCPYVAPHHLxIhERBvRgXRCjwCFZWUREGNCDdcGgHrhCpyOxmJqaqKqKPD0tXQ1Aj6E3Clxx4wY1NdHw4chQsDKIUeCKoiLi8TCiB+uDQT1wyA8/UFsbPf20pesAeBzojQIn7N5NmzeTiwulpNDu3dTQQPTTwcsAHIfX74ErWJbu3v3x3ykp5OBAKpVFCwLoGfRGgSvi4igl5cd/x8bSX/5CtrYWLQigZxCjwBUODuTpSW1t//HhpUuUlER1dRaqCaAHsMQEXJeURCtX0oABlq4DoBvojQKn7dlDAgGp1ZauA6B76I0CABgFvVEAAKMgRgEAjIIYBQAwCmIUAMAo/w8h8H7dPrwZTQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAXJklEQVR4nO3de1hUdf4H8PcwDDBc5CIiMASKkoBbqSAJKN61zHLd1ltr3kMqL4WZtm2rpl30Z5Zoq+IldTVdV4m0THTFC6A9hoq6omSEcncGkRlgZhzm8vtjzNqSS87InNH36y+ec758z+c8zzzv5/s933MRmUwmEBHRvXKwdQFERPaNMUpEZBHGKBGRRRijREQWYYwSEVmEMUqtzWAwJCYm5uTk2LoQIutgjFJr27Rp0/r164cMGbJ//35b10JkBYxRam1TpkxJTExUq9UjRoz47LPPbF0OkaXECxcutHUN9HBxcHAYPnw4gCNHjuzdu9fDwyM2NtbWRRHdO8Yo2YBIJOrXr5+Pj09GRkZGRoZWqx00aJCtiyK6RyI+DEo29M9//nPKlCl6vf6VV15ZtWqVgwOvMpH9YYySje3bt2/MmDEajWbcuHFbtmyRSCS2rojo92GMku0dO3bsueeeU6lUAwcOTE9Pd3d3t3VFRL8DY5QE4fTp08OGDZPL5TExMfv372/btq2tKyJqKcYoCcWPP/44ZMiQwsLCyMjIgwcPymQyW1dE1CK8ok9CERoampWV9dhjj+Xn5/fu3fvKlSu2roioRRijJCABAQGZmZkxMTFXr16dO3eurcshahFO6klw6urqOnTo4OXllZGR0alTJ1uXQ9QMxigJjlar9fDwMJlMKpXK1dXV1uUQNYOTehKcCxcu6PX68PBwZijZBcYoCU5eXh6Abt262boQohZhjJLgnDt3DoxRsh+MURIcjkbJvnCJiYTFaDR6eXnV1tYqFApfX19bl0PUPI5GSVgKCwtra2uDgoKYoWQvGKMkLJzRk91hjJKwMEbJ7jBGSVjMMfrEE0/YuhCilmKMkrBwNEp2hyv1JCAKhcLPz8/Dw6OmpoYfFCF7wV8qCcjZs2cBPPHEE9bPUK0Wly5BrbZyt0SMURKU8+fPA/Dw8LByv8XFmDYNubl45RWcOYOdO3H5spUPQQ8xTupJQLRabXR09MWLF2fMmLF8+XJnZ2fr9Pvuu3j+eXTtiooKLF2KTz6xTrdEADgaJUFxcXF58803pVLp6tWro6KiLl68aJ1+6+vRpg0AeHqirs46fRL9hDFKwjJhwoTs7OywsLCLFy/GxsZu377dou7KyrBlC4YOxcaN0Omwfj2eftpKlRLdxkk9CVFtbW1SUtLnn38O4MUXX1yzZo2bm9vv7iUzE+PGoaoKGRlwcMDx44iJwbBh1i+XHm6MURKu9evXz549W6PRDBnSKz19g1TataX/aTIhJQVvvAG9Hv37Y8cOtG9/PyulhxpjlATt0qVLY8eOXb1a6u5+Tib70M9vdvP/o1Jh8mSkpUEkwptv4r33IBbf/0rp4cUYJaHT6erLy2feuPEZAB+fvwQHrxGLG70jSq0+XVHwRsdBpxxEUmzbhqeeasVK6SHFGCX7cPPm7mvXphkMSienDqGhO93cnvxtG4ViXWnpa0ajNrD2LwGh7yM4uPXrpIcQY5Tshlb7fVHRGLU6TyRyDgpa6uc3CxCZdxmN2pKSGVVVGwH4+iYGB6eIRFa655SoOYxRsidGo7a0dI5C8Q8A3t5jQkLW1tefkkjaFRVN1GguODi4h4Ss8/F5wdZl0sOF942SPXFwcAkO/rRTpy/EYm83t6irVyeaTIaGhiqx2NvFpUt4+ElmKLU+jkbJLjU0lEkkAYWFI318Jnh5PWsw1Dg4uDo4uNu6LnoYMUbJjhmNWqXyS6Vyf4cOW2xdCz28OKknO1Zff9LZuYvBoLR1IfRQc7R1AUT3yGColstTRCKRpycfkydb4miU7JXD+R/9F1xFenpx8UyTSWfrcujhxdEo2acffhBt2eYWMEhaVaq8VaWrOO3s/yRa9s780tLSrVu3Xrt2DUB1dfXq1avb84l7sgBjlOzTwoVITYWrq3TSHtf8qoaKA87P9EBzr3k2GAyLFy9etmyZl5dXRUWFeWNUVNT8+fPvf8X0wOKknuyTyQRXVwDGJ8IdNKiNlTSboVVVVU8//fSiRYv0en1sbGxUVJRYLAagUqlao2B6cHE0SvbJZEJDAySS+u+C3y/d73hu4Pr1TTU/e/bs888/X1RU1K5du507dxoMhiFDhgDo2LHje++910o10wOKMUr2ad48zJ4NDw+Df+TmHU/3qG+q7bZt26ZPn65Wq6Ojo/fs2RMQEDBgwAAAoaGhmzdvFolErVQzPaB4+z3Zt5oaeHvD1RW1tXdZYdLr9X/729+WLl0KIDExcdWqVU5OTtOnT09NTQ0MDDx16pRMJrNB0fRg4WiU7JuXF/z9UVmJkhKEhPzPrrKyslGjRp08edLFxWX16tVTp04FsHz58tTUVKlUmp6ezgwlq2CMkn0zmTB2LAwGANBq4eJye3tWVtbo0aMrKysfeeSR3bt3x8TEAPjmm2/mz5/vFhExY8WKqx06hOh0fk5OtqudHhCc1JN902gQHIz//he1tfj3v/HWWwCQmpo6Y8aMhoaGbt26ZWRk+Pn5AcjPz4+Li1MqlRN27Hht+PAAJycfR0enlt1qStQE/obI7g0ahHffBYArV/DqqyWxsbHTp0/X6/Vt2rQpLCxUKBQAioqKBg0apNJoYg8flsXEHK2p2X/jhpiLS2QNnNST3WvfHqGhOHIECgVyc8tu3jzr6emp0WhUKlXv3r19fX1zcnL+/Oc/Ozk5mXQ6ibd3rcEwycdH5uzMGCWr4GiUHgSvvordu2E0Xq6sTNbpdEqlUqfTJSYmZmZmpqWl9e/fv7KyslOnTl9//fXWsLDH3NykYrEbPxdKVsLRKNk3R0fExkIsxqRJVyZNmgecNJng5OT06aefTpo0KTk5edWqVQASExM//fRTR0dHAH9ydm7jyF8+WQ1/TGTfamqQn4/q6uo5c0brdCOAvQBkMtnw4cMHDx589OhRFxeXtWvXTpw48c6/+EoktquXHkCMUbJvRiM0GtPAgQMrKq4DLuZHkl5++eVevXpdu3YtKCgoLS2tZ8+eti6THmS84Yns2/Xr6NGjuLx8O+AmFt8yGN784x//mJGRodFo4uPj9+zZw5fg0f3GJSaymvh45OcDwKxZrXfQ/fv3l5fvlEgWBAZuNRgMHTp0SE9P12g05vUlZii1AsYoWU2nTli2DCYT1GpUVbXGES9fvjx79nTgv9HR0eXlhU5O31+9etXJyWn9+vXr1q1z4hNK1Cp4bZSsRirFsGHYuhVaLdq1Q3AwBgzQdOmysmfPntHR0Z6entY93Pnz51977bXa2tLAwMPff39LJFLqdJ/5+/vv2bMnLi7OusciagJjlKxpxAi89BKqq+HhgeJi5OfXbN78FoBRo0atWLEiKCjIWgfavn17YmKiWq0GUF5eDsDd3T0sLCw9PT04ONhaRyFqCU7qyTpqaxEYCABvvYW4ONTU4OJFvPFGzYwZMyIiItLS0qZPn26VA+n1+vnz548fP16tVo8fP/706dPmdB46dOiJEyeYoWQDJiJrWLnS5OhoWrz4LrtKS0sBeHp66vV6C49SUVUVHx8PwNnZec2aNUajcdSoUQDCw8Nramos7Jzo3nA0StaRmgq9HpGRP28xGo3nz5/ftm2bTCbr0KGDUqm8ePGiJYfIq6ubWl4uevRRmUx29OjRpKSklSuv7tt3yNvbe+/evVa/9krUQoxRsoJjx3DxIgIC8OyzWLsWBQUAYP5y3IQJE6qrq/v06QMgKyur5X1u2bLlww8/NH/8A8DncnnS999f1+l6zp179uzZXr16ffEFkpM7hoWV7Ny5Oyws7P6cGVEL2Ho4TA+CsWNNgGnBAtMPP5gcHEyurqbaWpPJZEpISACwb9++devWARg7dmwLO7xw4YJYLDY/kvRYjx6zz+RF5eZG5+b+X3Fxg9FoMpny801t2pgA00cf3b/TImoRrtSTpeTyG/n5zo6O7tOmYdUqGI0YPRru7gDQp0+f48ePZ2dnmx9pb/lodO7cue5xcdHjx8vLy/VBIdlGvaNB/F7nkIE+3gC0Wjz7LFQqjB+P5OT7dmJELcNJPVlq06b15897TJz4oZ9fw86dJgBJSbd39e7dG0BWVlZ4eLifn19ZWVlRUVGzHWZmZh44cMCrc+eb+/f/LTJyaE0vdYHr+XFdFv/J+9AhALh+HcnJ6N0b69bdv9MiainGKFnEaDSmpqYCGDWq++7d/1YqO77wQsaTT97eGxcXJxaLc3NzNRqN+Zb4ZgekRqNx7ty5ANq3b1/dvfua69ffT+6yom2El0bq7Y2kJBQXIy8PMhmysuDqen/PjqglGKNkkQMHDhQVFYWGhg4ePHjt2rVK5bW+fa/d2dumTZvHH39cp9N999135pFpdnZ20x1u3rz5zJkzMpmspKSk6l//Wj1ggNTB4amhOHMGr7+Ol166/b0QIuFgjJJF1q5dC2D69OkFBQXZ2dkeHh7jxo37ZYM76dmSxXqNRrNw4UIA7du3b1Crnx85smvXruZd/v5wdYWPD3r1wjff3J+TIbonjFG6d3q93mAwuLi4TJ482cXFZdq0aUlJSR4eHr9scyc9e/To4e7uXlBQIJfLG+tw+fLlJSUlYWFhZ86c0R469OHMmb9tM2UKLLv9lMjK+L5Runc1NTXe3t5SqbSurs6hkS8VV1RUBAYGtmvX7vr164MHDz58+HBaWtrIkSN/21Iul4eFhalUqi5duhQUFCxZsuTtt9/+ZQOVCrt2wcsLkZFo1w7t2t2XkyL6vTgapXvn5eUVGBio0WiuXbvWWJuAgIBvv/22uLhYJBKZn+NctmzZvn37KioqftXy73//u0qlioqKKigokMlkr7/++q8atGmDjz7CqFEwGpmhJCC8b5QsEhkZWV5enp+f37Fjx8baPPnTyn1tba05VZ977jkAAQEBUT/x9fXduHGjo6NjZWUlgCVLlrjebRm+rAwArPeiKCIrYIySRSIjI//zn//k5+c/88wzTbesr6/fvn27XC4fM2aMQqHIzc2tqKj46quvvvrqqzttkpKSJk+evGHDhgkTJvy2B6UStbVwc4OXl5XPgsgSjFGySEREBIBLly412zIlJUUul8fFxe3cudO8pby8PCcnJzs7+/Tp06dOnQIwZMiQmJiYmJiYu/ZgHorKZNaqncg6eG2ULPL448/FxFTI5aubblZXV/fxxx8DWLRo0Z2NgYGBo0aNWrlyZXZ29quvvtrQ0HD27NkmOiktBTijJ+FhjJJFHn008NQp/6ws16bv+EhJSVEoFHFxcYMGDbprA/P2w4cPN9EJL4ySMDFGySK+vmjXDirV7Yy7q7q6uk8++QTA4sWLG2uTkJAgkUhOnTqlUqkaa1NWtsTXt2vnzustK5nIyhijZCnzq5rNn1a+q5UrVyoUivj4+AEDBjTWxsPDIzo6Wq/XN/G0aGlpaVVVvo+PzqJyiayNMUqWiogAGo9RlUq1YsUKNDkUNRs4cCCAzMzMxhqYP0Zixe/iEVkFY5QsFRuLwYNvf88OwLlzKC5GQ8Pta6UrV66srq6Oj4/v379/0/2Yx6pNXB4tKysDY5SEhzFKlsrIwIwZGD0as2YBwLBhCAlBly5PBQYGnjlzxnxVdMmSJc32ExcXJ5VKz507p1Aofrm9rKzs/Pnz+Gk0KuMdTyQwjFGylLs7vvgCdXVQq7FrF9q2hb8/FIq8ioqKXbt2VVdX9+/fv1+/fs324+zsHBcXZzKZjh49at6iUCjmz58fFhY2ZcoUlUp148YNiUTi5+d3X0+H6PdijJIVvPEGPvgAJhPGj8eFC2hoMNXVyb28vMxD0QULFrSwH/O8PjMzUy6Xz5kzJyQkZOnSpbdu3XJ2du7WrZu7u3unTp30ev19PBOi348xSlbQtStEIpSUYOxY9OuHxx+vc3FxqampiYmJ+fjjj/v27dvCfsyrTF9//XVoaOiKFSu0Wm10dLRMJjtx4kRRUVFDQ8Ply5fT09Pv56kQ/W58UR5ZKjUViYmoq8PSpfjlarxCodBqtY888kjLuzIYDL6+vjU1NUFBQd7e3iqVyvzuqNDQ0Hnz5mm12tmzZw8aNOiQ+ZNMRMLAGCVhGTFixN69e/39/c2vegoLC3vnnXdeeOEFsVisVCplMplarS4oKOCH6Uk4OKknYfnDH/5gztCQkJB169bl5+e/+OKLYrEYgKen5+jRo00m08aNG21dJtHPGKMkLPX19ZWVlSNHjrxy5UpiYqKj4/+8hCwxMRHAxo0bb926ZaMCiX6NMUrCYv7m3axZsyQSyW/39urVq1u3blVVVV9++WWrl0Z0d4xREhCVSnXu3DmJRNLYK0cBTJs2DUBqamor1kXUFMYoCcjJkycNBkN0dPRdvyBiNn78eDc3t8zMzCtXrrRmbUSNYYySgJhn9OZvMjfmzkLThg0bWqsuoqYwRklAysom9umzuW/f4U03My80bdq0iQtNJAS8b5SEQqeDtzc0GlRVwcenmcYRERH19fUHDx4MDw9vleqIGsXRKAlFbi7UanTt2nyGAvDx8SktLS0pKbn/dRE1gzFKQpGVBQBNXBdNS0sbMGDAjh07dDpdXl4egO7du7dWdUSNYoySUJi/HtK7d6MNDh06dOTIkeLi4u+++06tVnft2tXX17fVyiNqDGOUBMFkwokTQJMxevz4cQAJCQl3/mil4oiaxBgl2ysvR3U1Nm7Ea68hOPjubaqqqi5duiSVSqOiolpyXxRRq3FsvgnRffaPf6CyEhs2YN++RttkZWWZTKbY2FixWHzixAlwNEqCwdEoCUJoKA4caKrBnRFoXl6eUqns3Llz4J2v6BHZFGOUBGHqVGzdiibupueFURIsxigJgoMD5sxpdFKvUqny8vIkEkmvXr14YZSEhjFKtjdiBDw8EB6OSZPw7bcA0NDwPw1ycnIMBkPPnj2lUmlOTg44GiUh4RIT2V7PngDwwQdIScEPP0Asxo0byMn5uYF5BJqQkHDp0iW5XC6TyUJDQ21ULNGvMUZJKCZPxoIFOHgQbm5QKnH2LO48ozR69GipVDp06FBeGCUB4qSehMLfH8OHQ69HZCQAfPaZ4c6ubt26vfPOOzExMbwwSgLEGCUBSUwEAJFIHh+fumtX5/r6+l/uraysNH9amaNREhTGKAnIkCFISHj5xIn2N2+uvH796q5du8zbi4qKZs+eHRoaqlar33777UjzeJVIGBijJCAODhg8WAbAzc0NwJYtW/Ly8saNGxcWFpaSknLr1q2hQ4cmJSWJRCJbV0r0M762mYSlsrIyODgYwKRJk4qLiw8ePGgymSQSydixY+fPn89xKAkQY5QEZ+TIkenp6ea/3d3dX3rppeTk5KCgINtWRdQY3vBEghMREZGbm6tUKpOTk2fOnNm2bVtbV0TUFMYoCc7Vq1dLS0tTUlJmzpxp61qImsclJhKc7OxsAAMHDrR1IUQtwmujJCyFhYWdO3f29fWVy+VckSe7wNEoCcuxY8cAJCQkMEPJXjBGSVjuvIXE1oUQtRSXmEhYbt58Kz4+NiEh3taFELUUr42SgJSVISgInp64cQNisa2rIWoZTupJQI4dA4DevZmhZE8YoyQgx48DAK+Lkn1hjJKAMEbJHvHaKAmFQoH27SGV4uZNODnZuhqiFuNKPQlFeTkeewzt2zNDyc5wUk+CMHMm3N1x7hwGD8b779/eeOcPIiFjjJIg3Lx5OzQLClBQcHvjnT+IhIyTehIENzf07QvzR0Nqa/HXvwJAYaFtiyJqEcYoCcW4cZg8GQYDPDxuj0wnTrR1TUQtwEk9CYKvL0QizJsHJyf4+d3e6OeH9HQsWoRbt2xaHFGTeMMTCd3q1Zg6FVKpresgagRHoyRoW7ciMJDPhpKg8dooCVr37tDpYDTaug6ixnFST0RkEU7qiYgswhglIrIIY5SIyCKMUSIiizBGiYgs8v9FTHFHUrOO9wAAAo96VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHWRbUhTYRTH733udvfuNqe7a7q7i1MTar05tCC6zzkRi/JDKr2IGI9+ulEQCoaUpFISfihxYm++hGBKjqBZ1pdaRRH0YlhB9EEi+5RhmiHUh8A2phhaBw4/+P//z+Ecntn4zY9coqyJ5rlU+ROdk+hmXmQFCQo6kW1NktctC4tUNv1FssyVudWD/jfxH4lV0ZWOSVGS+y/CoKRkwZB6sMyUQVYZRiV57wK/RIeS1PU6C2dknFMjnKTwRCO8xIjAiE0RTBoRPEyn5/QiJ8qcwagRg4sZ3IoxgzOZmUliZotGLFZm9WjEukaxpWnE5mBpXmb3asSexRxZGnGmM2cml+7SiFvmsmXOJ3MZOj1PBJMkGlzpTs4omi1Wj2AS07z2LIdN4pc+yb/uXA01awNw93Y29s1a6JeKftDvysPvQ6/V89IVqNtTgG3wS82V2oGW52HVxAm1auINPAta8VOPnmodz6H6iRU3LEyp91vjUFtpxsmTDTSmRmEu5ML28n2049sA7AxKmHNsPS1bG4GmYQULC8M08rINpqkPSwa30PcHTkO4TsaeQkJHBxtgLhDA0eJD6quqq7C7OojBEZv6dPMASD83YtF238PH23rg4HQROqYu7ZCHOhI7b8If0Emd4Sj0u2Xs3n+DNk7GIKPJi6HmXsqPxWDEl4kzjXbq6eqD4dpM9D66Rn9fjkI9BvDIcUbPlEbBcMuG3tIiOtjdC/0XFSz2jqv+1rMwdiof5aEPakt+DbQezcX6Tk/8TsV1aOkK4deut3FnOAL3PoewMraXXhBjMFYioH8+QgMvHsDIjBHn5stobHwU3h02ofsPPIW7Mhe0pJwAAAKselRYdE1PTCByZGtpdCAyMDIwLjA5LjEAAHiclZZJilsxEIb3PoUu4KImlaqWoZ0BQjqQQO6QVTbp+6c0vGdDd0NkDNb/yvpco2R7efkDHy6lv37cvv7+W86X3C6XIlRES8E33xFRfjEijv0CVaLmghFqRe+PAqjVWp7Ke4jH96AwkNuikHnkSgmEmu5QCIy0Uyg9kMFTBmzc9igxI6IG7ibLFyHZoSCEad/LBixsPS8VUHXLl/TeW+uLChSGk0KRed6KyNmpUwScavdKFKrHVkS513nUiEDROk8MHGkrIgGulWaljWZEDVoo7+XFQjuFHNiCe41659hW1wkQ8ao0s+rs3Sz0Vtdxek99L1XwMJ4UI7LNSosuSlVsM6LmmautrnNVmxPAUfs0qoBoxT1KrXLMNI8uTkrE1gRce32Vpy+VfdSoQpO93sWMw9qqNFqPTRXQ9k4GBUPyo3ejzRpV5q3s1vSFxjRyzvToYnEw1i2KQjDFovCkZP+12KpR7lXGmV1n9kkRIyyftnwJ5pUXjdV1Tho7lLwD0I7skvo8pbRH+bwTkau3GVFDwjXT2miHkncAj74ng2oV5+ltjFu+5I4YZzZp3iRjLpNCmLz/p1y794HrrDP3OQGktklRIlkT4NomJVtXdyLKs8559S7NaZTMOGdE319T6N1+qcEyb5LG0uZNwnk57lCkzzRPX1oe35Mimhn/+Zryxh+Ry2DH/IUh+nDzIVhPSz6T08KPFhnkU9BdaOnNx4foN8Sy5MpOkat2itb/Mx3Ch298CMYHS8/eEpHzcoj8RXoUd0fzMfFByxWdgFx13/gUp28ZDN0tKU5H8zHfhQ3Bp/DT0oZYFi905jpFPzCWiBHc/FpGds8Bx4MQvItvpTx9+Tz25HfKNR+mOT+75ePz7fIPeDGqob9+SmgAAAG4elRYdFNNSUxFUyByZGtpdCAyMDIwLjA5LjEAAHicJZI7jhtBDESv4lACWkTzT2LCBTZcBw4NR5PrBHt4F3shYKB5U10ki/3x8fHn8ff369/z5/l18/34fN6P11tuPG+93/jpE38A7sfX842Xkdz86/uxqcN0SZCoxFKnbZaX0K7MJU7ch3LvuphKipcoFbsuNfJqvZSkQ5YIpUQPVpMA5pIczFKyVHDaL5xp0fFI0RyxqDLEvqOWMBlbTUUTbuDCoYN38NKg2pxT0R2NbApGe0nZJmhaTBY36kgN1TjG2j5S9w3axOkObVnliHPzsk1syaBcccQc1cuYlNMwd7D5iFnx2ZBOSl4bHhaDpb2WKeb2awrpT0FBsqDdrNdrSvRpOQpiRGoxFNanaZ+QgFORNLgx6+IiKcvhImwwR9R58I5YZrTjNNgzJCfiCj19K2oKRRsfdbScKSN8FsNy1CJmEwnEBnU222KnmnUCB3PMVVA72G3nmGQ5TyaNC8OGTPAZJXn7UEEUHOQT1Lzuxs5j889yd+c4O6YB7hY52Po4FyK6MGrzuTeiWLIWTOyocSMOlsHoPvv5/R9bA53yALWZzgAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f1a63885bc0>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f0bde86a9e0>"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10852,7 +11113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
@@ -10886,17 +11147,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3de1xU1doH8N/MMIDDMFwU8YKIiKCCF8I0JVOTNBLMULLjpYtvgaeOaGYOeQNTc5IyNE3JNHk7+Sk6+RZ2U0wzzAzBBBQEQbxwEQQGhjvMzHr/2EgcvKQwM5uZeb6f/mD27NnrGcyfa6+199oCxhgIIYR0lpDvAgghxLhRjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBKiS2q1WqlU1tTU8F0IMRwLvgsgpLs4ehRz5+LiRTg54ckn8dNP+L//Q2oqNBrU1ECtRm0tWlpQX4+mJjQ0AJheVVXU0NDQ1NRUX1/f0tJSW1vLHcrPzy88PPyVV17h9QsRA6EYJeQvM2di/Xrs2NH68osvkJBw15179rxWUXGxw0aRSCSTyXJycsLCwmxsbObNm6e3Ykl3QTFKWuXm5lpbW/fr18/Cwnz/r/D2RlERMjJaX4aEYORIWFhAKoVYDBsbWFqiRw9YW8PaGhJJgqWlQCKRiMViqVRqYWFha2vLffDTTz9dtGjR8uXLAwMDHRwcePs+xCAEdE894fj4+Fy4cCEzM9PHx4fvWvhx9CjOncP//A/CwlBTg59+6vyhGGMBAQHHjh1bvHjxrl27dFcj6Y5oiom0qqysBODo6Mh3Ibz57TccOQILC0yZgoKCLh1KIBDs2rXLysrq448/PnXqlI4KJN0UxShpZeYxqlbjwAEkJeHLL/Hqq8jJ6eRxDh48uGXLFgCenp4rVqzQarWLFy9uaWnRZa2km6GTegIAtbW1tra2NjY2bXPN5mb3bvzzn/D0xPnzEIs7eZDc3Nzhw4cLBIK0tLSRI0c2NTWNGjUqJycnJiZmxYoVOq2XdCPUGyWA2XdFGxqwaRMAbNrU+QwF4Onp+a9//UutVr/yyitardbKymr79u0AoqKiCro4TEC6MYpRAgAVFRUAevbsyXch/PjgAxQWYswYzJ4NAF25dn7Dhg0uLi4pKSkff/wxgGnTpv3jH/9Qq4Xvv1+io2JJt0MxSoBbvVHzjFGlEu+/DwAKBQQCNDZi5EjMnw+VqjNHs7W13bZtGwC5XF5cXAxg69YPhg0r27lzwsGDuiybdB8UowS41Rs1z5P6d95BZSWmTcPUqQCwcyeuXEFmJqTSTh4wJCQkODhYpVKtXq0A0KePc3h4DwD/+heqq3VWNuk+KEYJYMa90aIifPQRBAK88w4AVFdj82YAePddCLvwl+PDDz98/PF9iYnbjhwBgPBwTJiAkhJER+ugZtLdUIwSwIx7ozt35jc24tln4ecHADExqKjAxIkIDOzSYQcOHPjkky9VVgpeew0NDRAKsXs3xGJ8+CHOntVJ4aQboRglgLnO1GdnZ2/Z4jV06LyNG9UAysqwfTsAKBQ6OPjrr2P0aOTltfZzR4zA0qXQaBAeDo1GB8cn3QfFKAHMdaZ+1apVGo1m0iR7Dw8LAFu3KmtqMGsWJkzQwcEtLBAXB6EQW7YgKwsA1q/HoEFITQXdHWpiKEYJYJa90ZSUlG+//dbGxmbt2rUA8vLyPvig7/jxMZs2aXXVxNixCAtDczMWLwZjkEiwcycArF6NoiJdNUL4RzFKALPsjUZGRjLGXn/99b59+wJYs2ZNc3PT8OE5w4fr8i/F5s3o0wcFBbh+HQACA/HMM6ivx7FjOmyE8IxuBiUAMGzYsIsXL2ZnZw8dOpTvWgzhhx9+mDFjRq9evfLy8uzs7NLT0x966CFLS8vc3NwBAwbotq3UVHh54dYSeigqQlkZfH112wjhE/VGCWBmM/VarXbNmjUAVq1aZWdnB+DNN9/UarVLlizReYYCGDPmrwwF0L8/KirQsydu3gSAJ5/UeYPE0ChGCRhjSqVSIBCYyQLDBw4c+PPPP/v377948WIAJ06cSEpKsre3l8vlBquBW2afmAaKUQKVSqVWq2Uymbgry3IYiebm5ujoaACbNm3q0aMHgK+//hrAypUrDTk07O0NsfivZfaJUaMYJeZ1Ri8Wi2fMmCGTyYKDg7kt27dvP3z48NKlSw1cybp12LDBwG0SvaAYJeY1Tc8YS01NValU69udVE+bNk0ikRimAK0WaWkA4OCgg2X2SXdAMUrM66JRoVAYFxcnFot37Njxxx9/GL6AL79EZCTOnAHQpWX2SfdBMWruGGNJSUkwm94oAB8fn2XLlmm12tdee01j2BszW1qwdi0ATJ9uyGaJflGMmi+tVnvo0KGxY8e+//77Y8eOXb58Od8VGU50dPSgQYPS0tJ2cvcVGUpcHPLz4eWF5583ZLNEvyhGzZFarf7ss898fHxmzpyZmprav3//+fPn+3FrHJkHiUTCBeiaNWsKCwsN02htbeujShQKWFgYpk1iEIyYk+bm5vj4eE9PT+5Pf+DAgbGxsQ0NDXzXxY+QkBAAs2fPNkxz69czgI0dy7RawzRIDIRuBjUXTU1N8fHxGzduvH79OgB3d3e5XP7SSy+Zw7Wid1NSUjJs2LDq6urExMS265/0pLwcgwdDpcKxY5gyRa9NEYPjO8eJ3tXW1sbGxvbr14/7E/fx8YmPj1er1XzX1S1wz01ydXWtqanRa0NLlzKAzZih10YIPyhGTZlKpYqNjXV2duYCdNSoUfHx8RqNhu+6uhGNRjNu3DgAK1eu1F8rBQUaKysmFLJz5/TXCOENndSbpvLy8h07dmzfvl2pVALw9/eXy+VBQUECgYDv0rqdtLS0cePGCQSCM2fOjB49Wh9NvPjiory8R0aNmrdzZ2efk0e6M75znOhYaWlpVFSUTCbj/nz9/f0TExP5Lqq7i4iIADB27Fh9dNUzMjKEQqGlpWV+fr7OD066A4pR03H16tWIiAhuuQ0AAQEBv//+O99FGQeVSuXi4gIgLi5O5wefMWMGgKVLl+r8yKSboJN6E6HVaj09PfPz84VCYUhIyOrVq/V0fmqqvv766zlz5tjZ2WVnZ3Pr4XPUanVVVZVKpdJqtdXV1YyxqqoqANxoSXV1tVarValUGo2mpqZGrVZPnDiRy03OyZMnJ06cKJVK8/Ly2gapianhO8eJbsybN08qlU6ZMiUrK4vvWowVd83T/Pnz229M49YRuW8rVqxo/3F/f38A69evN+xXIQZFvVETERAQ8PPPPyclJQUEBPBdi7G6du2at7d3bW1t+19jTk6Ov7+/nZ2dQCCwt7cHwC1ubW9vLxAIZDKZSCSytbW1sLCQSqVisXjcuHGTJ0/mPvvtt9/OmjXLyckpPz/ftv0K+MS00C1pJsKsFrvTE1dX17Vr18rl8n/+85+ZmZnW1tYAvLy8ysvLO3E0jUazevVqAOvWraMMNW10T72JMKvF7vRn+fLlo0ePzsvL27x5cyc+Xl1drVQqr169evny5U2bNl24cMHNze2VV17ReZ2kW6GTehMhlUrr6upqamqkUroysUtSUlLGjx8vEokWL14skUhaWlpqa2vVanVNTY1Go7nbXFNVVdXtf5VsbGx27969YMECHr4GMSCKUVPQ3NxsZWVlaWnZ1NTEdy2mYOzYscXFxUVFRQ/6QW6olBsktbGx+frrrwcPHiwU0jmfiaOxUVNAA6M6VFJSkpWVVVdX9+KLLw4dOtTCwsLW1lYkEslkMqFQeLe5Jjs7O4pLs0UxagrM6pl0+vb222/X1dWFhIR8+umnfNdCjAP9+2kKuPkl6o123aVLl/bu3SsSiTbQQzvJfaPeqCkQi2vmzx/Rr98gvgsxemvWrGlpaXn55ZeHDx/Ody3EaNAUkykoL9979erLvXr9z8CBn/BdixFLS0t7+OGHrayscnNzBwwYwHc5xGjQSb0pUKsrAIhENDbaJZGRkYyxiIgIylDyQChGTYFGUwnAwoLGRjvvl19+OXr0qL29vVwu57sWYmQoRk0B1xu1sKDeaCcxxiIjIwFERkbSBQ/kQVGMmoJbMUq90U5KSEj4448/+vXrt2TJEr5rIcaHYtQUcCf1NDbaOWq1Ojo6GkB0dLREIuG7HGJ8KEZNAfVGu2LPnj0XL1709PR86aWX+K6FGCWKUVNAMdppDQ0NmzZtAvDOO+9YWNBl1KQzKEZNgVpNJ/WdtHXr1qKioocffjgkJITvWoixosvvTYC2tHSrRlPVr99GvisxMkqlcvDgwUql8ujRo1OnTuW7HGKs6CyGJ4xBLodKhZYWDBmCyEgcOgS1GmVl+PxzODqiZ084OsLREb16oWfPJr/e2t4yC4ueIpGjUNij7TCNjReLilaJxf0Ya+Dx2xipjRs3KpXK6dOnU4aSrqDeKE8OHEBhIVauBICICMyZg8ceA4AlS7Bjx+27X/nZv8LuN+5nobAHl6cWFo49evja2Pg5Os7n3qqrO8NY4613ewoEYsN8G2NUVFQ0ZMiQxsbG1NTUhx56iO9yiBGj3ihP0tMRFNT68/jxSE9vjdE338Szz6KiApWVqKho/a+yUmwr7dFDpVZXajQVWm1Dc3MhUAigT5/I2trfrl59xcLCsV+/jUVFkTU1x9oaEYlsuTx1jx9mdVXzVw+X+6FnT/j5QWymUbtmzZqGhoZ//OMflKGki6g3ypN//xulpXjjDQB4/XU8/TRuPU7yb2m19Wp1pUZTqVZXSCR+IpEMQGHhSpksoLr6x/r6VC5t1epKxlq4j4wI72eZVnyHY1VVYdOmO4wtPPPMvWtIUak+Ki72lEjsRaJX+/e/32/dbVy8eHHEiBECgSArK8vDw4Pvcohxo94oT+bNw8qVeO01tLTAze3+MxSAUCixtJQALgCqqr5RqQ4LBJYtLSU2NmNlsmnt99RoVFzaimMqcaO8tYdbWdn6Q1UVvvsOvXphyxYAiIjAr78iOPg+y5hsb/9inz73Xzbv6urq8m/Zu3evWq1+9dVXKUNJ11GM8kQoxHvvdf0w9vazhEJJbe1JB4c5IpF9h3dFIplIJLO0dMOUu3xeLr/z2MJ9+KWqqri52cfGZmb3Wy5aqVRevs2VK1e0Wi23g1AotLW1nT17Nr91EtNAMWr0VKojpaXvi0R2UunEB/7wiBFIScHEiQCQkoKnn77/j3aH3ihjrLCwMP823DM7O7Cysho0aNDgwYMHDx6ckZHxyy+/7Nmz5/HHHzd82cTEUIwavS4t79SFsQUenT59+p133snLyysoKGhsbLx9B5lMNvi/eXh4uLi4tD11rqSkxN3d/auvvoqOjvby8jJs+cTUUIwavVtrNnfqzLqzYwvpdXW59fVZdXXDbWw6024XJCcnb9q06fDhw9xLBwcH99sMGjRIIBDc4yB9+/Z98cUXd+/erVAo6NF1pIsoRo0eL2s2n62pOVNTE9q7tyEb5Zw4ceLw4cMzZ858++23Bw8eLJVK771/aWlpfn5+Xl4ed77/9ttvu7u7A3jrrbf27dv32WefrV69miaaSFdQjBo9XtZsrtZoANiLRIZslJOZmQkgJCRk1KhRHd5SKpUXLlzIyspqm1a6dOmSSqVqv8/cuXO5GHV1dZ03b97+/fvfe++93bt3G6x+YnooRo0eL8s7VavVAGR8LInExejIkSO5l8ePH4+JicnPz79y5Upzc/Pt+zs6OrYfJPX19W17a/Xq1Z999tm+fftWrVrl6upqmPqJ6aEYNXZMo1ECApHIwZCtqtRqAHYGj9GmpqZLly5ZWFgMGzaM21JTU/Pjjz9yP98+Turt7d23b9+7Hc3DwyM0NPSLL77YunVrbGysIb4AMUV0F5Nxa2hoOnNmobV1/dix3xms0WbGJpw9KxYIfjf4bZRpaWljxozx9vY+f/48t+XmzZunTp3iepo9evS498dvl5WVNWLECEtLy8uXL98jcAm5B1pv1LiVlFhNmpTw3HOGy1DcOqM3fFcUQEZGBoARI0a0bXFycnr66ad9fHw6kaEAhg8fPnPmzMbGxm3btumsSmJmKEaNW2UlABj4NiK+zuhxa2C0fYx23bp16wQCwY4dO8rLy3V4WGI+KEaNW0UFABj4kcCtvVH+punb5pd0wtfXd/r06XV1dTvutEQhIX+LYtS48dMbbW4GT9P0paVi6Lo3CmDdunUAYmNj73gXKSH3RjFq3HjpjeZ/882fjzzSsHOnQVsFSkuRmfmDq6tG5xcnjR8/fvLkydXV1bt27dLtkYk5oBg1brz0RsvLy7VqtdTg6z2npwOAm5vw3jd6ds6aNWsAvP/++7W1tTo/ODFtFKPGjZfeaGVlJQBHA7cKZGQAgE7HRf8ydepUf3//ioqKPXv26KUBYrooRo2bpSWcnODkZNBGuRjtafBlRjMzAUDX46J/eeuttwBs2bKloYGeD0geAMWocYuJQVkZ5s0zaKMVFRXgrzeqvxidMWPGmDFjbty4sX//fn21QUwRxahxOHoUCkXrzwEBrVt69sTNmwDw5JMGLYaX3qhajexsCATw9tbxkdvfyBcZGQlAoVDc8fZ8Qu6IYtSIzZyJ9et5aJeX3mhODpqa4O4OmUyXhy0oKHjkkUcuXLjAvQwJCfHx8bl27dratWspScl9ohg1Gt98g8WLsXgxSktbt3h7QyxuPdU1JF56o/qYX8rKyvL3909JSYmOjm7b6OLiYm9vv2XLFgcHhyeeeGLbtm3Xr1/XZavE5FCMGo1Zs7B7N3bvhrPzXxvXrcOGDa0/r12L//zHEJXwMlPPzS/pMEbPnTs3efLkkpKSSZMm7du3D4BWqw0PD//pp5/q6uo8PDzq6+uPHj26bNkyV1dXX1/fVatWnTx5UqPR6KwCYiooRo2bgwOmTEFBAVJSsGkTQkMxb17rxaT6kJ6evmDBArFYLJVKt23b1vagTQN47DG89hqm3O0Rpw8oLS0tICDg5s2bgYGBP/74o62trUajWbRo0Z49eyQSyXfffXfp0qVr167FxcXNmjVLKpWeO3du8+bNEydO7N2797Jlhf/7v62j0oQAACMmQatlcXFMKmUAc3Zm33yj4+OfPHkyMDCQ+3/G0tKS+2HKlCkFBQU6bkn/kpOTZTIZgODg4MbGRsZYU1PTnDlzANjY2Pz8888d9m9paUlOTpbL5X5+flZWMhsbLcCEQubnx+RylpzMNBo+vgbpNihGTUpBAZsyhQEMYKGhrLJSB8dMTk4OuvUse6lUGhERUVRU9P333/fr1w+ARCKJjY3VarU6aOkukpKYoyMrK2OMsenTu3q048ePc49veu6555qbmxljjY2Ns2bNAmBvb3/q1Kl7fzw//8b27ezJJ5m1devvGWC9e7MXXmBffqmbXzgxOhSjpobrltrYMIC5urKkpM4fKikpafz48VyA2trayuXyioqKtneVSuWCBQu4d6dNm3b9+nUdVH/nMtiLL7LXXmOsyzH6/fffW1tbA1iwYIFarWaM1dXVPfHEEwAcHR1TUlLu/1D19SwpicnlbOjQv/J0wQJdJj4xFhSjpikri40dywAmELDo6GO1tbX3/1mtVpuYmPjwww9zEdmrV6+oqCilUnnHnRMSEnr16gXAzs4uLi5OR+UzxlhlJYuOZps3s6QkFhPDli1j6els+nTW3MzeeosVFT3wARMTE62srAAsXrxYo9EwxmpqaqZMmQLA2dk5IyOj06VeuMBiYtjjj7MPP9RZ4hMjQjFqslpamELBxo0rFwiEgwYNOn78+N9+RKPRJCYmtj30rXfv3gqFoq6urm2HlJSUAwcOdPjUjRs3uJNiAE899VRRJxLuv5WWsshIZmvLACaTsW+/ZTExrLKSzZnDpk9nH37IACaRMLmc3SXb7+DAgQMWFhYA3nzzTW6LUql85JFHALi6uubm5naxZk6HxCdmgmLUxJ07l849iFgoFK5YsaKhoeGOuzU3N8fHx3t5eXFpOHDgwNjY2Pr6+rYdTp48GRQUJBAI7Ozs7tgzTUhIcHBwAODk5PSf//ync9XeuMHkciaRtJ4j+/uzo0dbs4kxtnMn8/RkFy+y0FAmEDCAOToyhYK1K/POPv74Y6FQCEAul3NbSktLuV+Lm5tbfn5+56q9HVdqW+ITM0ExavpaWloUCoVYLAYwbNiwDiOATU1N8fHxgwcP5gJ00KBBsbGx3Pw158iRI4899hj3rkwmi4yMrKqqumNDxcXFM2bM4PYMDQ0tLy+//yKvXGEREaxHj9aBiKAgdvr0vfZPSWGPP96atv37s7g41tJy5z137drFLaz37rvvcltKSkp8fHwAeHl5FRYW3n+Rf6st8T/4gLm4sLv8noipoRg1F+fOneP6XxYWFnK5vKmpqba2NjY2tn///lzweXt7x8fHt7RLo6SkJO60lwvQDlNMd6TVauPi4ripcGdn52/u48KrnJycJUs2W1oy7iqiuXNZevr9fqmffmK+vq1hOmwYS0xU3X7NwOnTp2UyWWxsLPfy6tWrHh4eAIYPH15cXHy/LT2ggAAGsIMH9XR40r1QjJqRhoaGN954gzu9HThwYNttSH5+fgcPHmwLIG6EdMyYMdy7Tk5O95hiuqPLly9Pnjy5rVtaeZfrgDIzMxcuXMgNWY4fXxQayrKzH/hLabUsIYENGcIA5uv7xtixY48dO9Zhn9LS0rbCBg0axH3lB+osP6ioKAawpUv11wLpRihGzc6pU6fc3Nz69OkDYMKECYmJie0DNCEhYdiwYVwCOjs7d5hiun9ct1QikXBzOEePHm3/7pkzZ2bNmsWda1tZWYWHhxcUXOnKl2puZp98Uu586z7ZwMDAc+fOddgnOzub63o/+uij1dXVXWnubx0/zgA2erReGyHdBcWoOdq7dy93sWfbFm6KydPTs/0U093mo+5fVlYWd+GUQCAICwurqalpm6riAjQsLEyHF5zW1tYqFAp7e3uuxdDQ0EuXLnFv/fnnn05OTgAmTZqkUql01WJ7KhX74Qf222+MMdbQwKytmVDI/m4UhJgCilFztG3bNgBLlixp28Kts8nNuuzfv7/lbvM1D66lpWXDhg3c/aPcVH7bxfxt59q6VVFRIZfLucvsxWJxWFjY4cOHufWoAgMD6/92Xr+zPvmEAWz27NaXEycygCUm6qk10o1QjJqjqKgoAFFRUW1brl696ufn98UXX2j0c394Zmamm5ubq6urRCK5n6mqrrty5coLL7zADQRzIR4SEtLU1KS/Fi9dYgBzcmLcGMmaNQxgb7yhvwZJd0ErPJkjbt3l9guGurq6pqamzp07l8sdnfPx8XnmmWeuXbsWGRmpUCgMsMjewIED9+/fn56ePnHiRDs7Ozc3ty+//LJtURV98PBA//64eRPZ2QAwaRIAnDihvwZJd0Exao54WTC0qqoKQNv1VYbh4+Nz4MCBmzdvKpVKfTyWuQPu+louOidMgKUl/vwT1dX6bpbwjGLUHN3eG9WH/Pz8BQsWxMTEcC/5ep6oi4uLu7t7dXV1Ovece31q3wOVSODnB40Gv/2m72YJzyhGzZFhEu3y5cuff/75kSNHuJd8PU8UwKRJkwCc0P8JNnex7IkT4J6SFxJyZsSIxSdPRum7XcIvilFzZJhE69Dn5as3CgPGqJcXgoKSevZclJOTA2DEiMrMzLhjxw7ru13CL4pRc2SYk/oOI7C890aTk5MN8NQTieSTCxc+/fXXEwD8/f3FYnFaWlpNTY2+2yU8ohg1O2q1WqVSiUQimW4fVXybDmGtVCrBU4y6ubkNHDiwsrLy/Pnz+m6rfc9XKpX6+vqq1erff/9d3+0SHlGMmh3u7ngHBwc9XdvUpn1vVKVSNTc329ra6vWSo3vgFqkywHk9F6PHjx9v/9IA7RIeUYyaHcOc0XdoiJdLrNozWJwNHz68d+/eJSUl+fn5hmyX8Ihi1OwYbKqnfXQaLLvvhouzX3/9lXGT6HojEAgeffRR3IrORx99VCQSnTlzpr6+Xq/tEh5RjJodg031dKveqIeHx4ABA27evJnN3WOkT5MmTbKzs+NuN7Czsxs1alRzc/Pp06f13S7hC8Wo2TFYx7B9t5f33igArpP4yy+/6LuhsLCwioqK5cuXcy+5pVe/+uorfbdL+EIxanYMdlLfvtvL40WjbQw2TGltbS0SidpelpaWOjs77969u0+fPs8///xXX31VTfeHmhaKUbNjmPNrrVZbVVUlEAi41T95vGi0DdcrNMDwaBvG2LJlyz7//POKiopevXqVlpZ+9tlnzz77rLOz87Rp0z744IPc3FzDVEL0imLU7Bgm0aqqqjQajb29PfeMEN7HRgF4eXn169fvxo0bhgkvxlhERMS2bdssLS0TEhLKysrOnj27cePGCRMmqNXqpKSk5cuXe3l5eXh4REWV/PQTGhsNUBTRC4pRs8PjLUz8ntTj1vCoAc7rNRrNokWLduzYIZFIDh069MwzzwgEAl9f39WrV//2229lZWUJCQlhYWF9+/YtKqp4772+gYFwdMQTT+Ddd5GTo+/qiI5RjJqd24cp09LSDhw4oNtW7nhDPb+9URhqeLSlpeW5557bv3+/jY3NoUOHpk2b1mEHR0fH0NDQuLi4wsLCX39NeeMN+PmhsRFHjyIyEkOHwtsbb76J48fR0qLXSomO8LpoNOHB6NGjAZw9e5Z72djY6O3tDWD27NllZWW6auWHH34AEBgYyL3kHtR86tQpXR2/c7ibQfv27dt+4/Xr13NycnTVRGNj46xZswDY29s/0PctKWH79rHQUGZn1/rIaIC98AJzdGTcH8v06YwxlpTENm9u/cjUqbqqmnQJ9UbNjqWlpUgkSk1N5V5aWVlFRUU5ODh8/fXXPj4+Bw8e1EkrgYGB1dXV+/fv5152k95oh1uMOLt27fLy8nJ3dw8PD//qq69qa2s7ffz6+vrg4OBvvvnGwcHh8OHD48ePv//P9umDl15CQgLKy3H8OFauhI8PxozBzJlYv77TFRGD4DvHiaElJydzf/QLFy5se/r8lStXpk6dym0PDQ3V+TPcubP7mzdv6vawnRASEgJg7969bVvWrVvXq1evtr8REsbnCnwAAAWcSURBVIkkKCjoo48+KigoeKAj19TUPP744wCcnZ0zMjJ0Um1SEouJYcuWsfT0v3qj48ax8HAWHs58fHTSCOkqilGzwz1BXiqVAujTp0/irWdXdtj+7bff6qpFjUYjEokEAoEOHzjaadxTUZ9//vn2GzUaTWpqqkKh8Pf3b79ii7u7e0RERFJS0t8+C0+pVHIDFwMGDMjNzdVVtVyMVlayOXPopL77ohg1U5cvX+YWPeK6pW2Pbr98+TI3D9Nhe6dlZGTMmzdPJpPZ2trGxcV1ufCu4h4lYmtrGxoaGh8fX1lZ2WEHbhp94cKF3BWvHBsbm6CgoLi4uOvXr99+zLKyMm7E2c3NLS8vT4fVcjHKGNu5k3l6tm7pEKM//MDefZctXarDZsmDoRg1XxqNJjY21srKCsDAgQN//vlnbjvXLZVIJB22P6g//vgjODiYe5CcWCzm8ig4OLikpER3X+KBaTSatlXsAFhYWEycOHHz5s3p6ekd9lSr1ampqVFRUX5+fm2PwwsODu6wW0lJyYgRIwB4eXndMWQN49VX+WqZUIyavQsXLowZMwaAQCAICwurra299/b7kZycHBQU1NaPi4iIKCwsTEhI4EZI7e3tee+W5ufnx8XFBQUFcf+KcHr37r1w4cKEhISqqqoO+1+9enXXrl3BwcH79u3rsH3IkCEAhg8fXlxcbMBv8F9iYlhKCl+NE4pRwlhLS4tCoeAWVHZ3dz9x4sS9t99DcnJy21SVVCqNiIhoHy4lJSUzZ87k3p0zZ053mHGqq6tLTEwMCwtzcXFp30X19/dXKBSpqan3+GxBQYG7uzuAhx56iMfvsm0bmz+fffAB02r5KsHcUYySVhkZGb6+vgCEQmFERERjYyO3/ezZs9xJ61NPPXWPjyclJY0bN46LIZlMJpfLbx925MTHx9va2nK9v4MHD+r+m3TW+fPnFQpFQEBA2xAEgEGDBoWFhSUkJNTU1LTfOTs7u3///gD8/f1v770Ss0IxSv7S3NwcFRXFrU7k7e195swZbntjY+PatWvvOPCn0WgSExP9/Py40HFycoqKivrbWCkoKOAWCgEQuXWrSq3W/ZfpgoqKirabNdvytEePHgEBAQqFIjs7+/z589xbkyZN6vosHDF2FKOko9OnTw8dOpQ7t5XL5Xe71kej0SQkJAwbNoxLGWdnZ4VCUVdXd5+tcBNZPfv0mZmWNi09/US37NBpNJrTp0+vW7duzJgxbbNM3HgFgMDAwPr6er5rJPwTMEMtGkaMSENDw/r162NiYrRa7ciRI+Pj47kLejjNzc1ffPHFxo0bL126BMDNzW3ZsmXh4eHW1tYP2lCBUrmhtDSjrk4APOPktMzFRaLnB+11Wnl5+fHjxw8dOvTdd9/NnTu3rq7uk08+4esJfaRboRgld3Xq1KkXXnghLy9PLBavWrVq7dq1arU6Pj5+w4YNhYWFANzd3eVy+aJFi7jV8DpHC3xZVvZhYWEzY/0sLde5uY2xtdXdl9A9tVrd1NRkY2PDdyGku6AYJfdSU1OzYsWKPXv2MMaGDBlSVVV18+ZNAKNGjVq1atWcOXN09ZTmyw0N0VeuZNXXC4BnevV6fcCAHt21W0pIBxSj5O8dOXLk5Zdftre3z8zMHD16NBeg7ccKdULD2L9LS3cXF7cw1t/KKtrNzVcq1W0ThOgDxSi5L1VVVfX19bm5uW0z7HqSXV8fdeXK5YYGjx49Xndx2VVc7CmR2ItEr/bvr9d2Cek0ilHS7TQzFldcPNXBoVatzqqvf7FPH74rIuReKEZJ95WiUn1UXOwpkfjY2Mzk+wEkhNxN5ydYCTGAyfb21Bsl3RxNhhJCSJfQST0hhHQJ9UYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRL/h/s60VWu6olBAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvomK+y5uIKJkWmJp4laiP/NaSYleLaybNm6Ja3fQFnJJx9stqW4ZZiqaaWSmGGoQKiCmSYgoKjIMw7DNMDPP74+DI+4IszDM9/3qxWvmcHieZ0w+fs95znkOjzEGQgghjcW39AAIIcS6UYwSQkiTUIwSQkiTUIwSQkiTUIwSQkiTUIwSctv58ygrq3t94QI0GouOhlgJilFCbps5E6+9Vvf6n/9EcbFFR0OshNDSAyCkedFq8cMPGDMGAGprUVyMigpotVCpoNOhvBx6PZRKAFCrc6uqjpWVlTHGuK9KpVKv15eXl+t0unnz5vXt29fFxcWyH4eYAcUoIXdYswYvvoinngKAAwcwZ84D9xw+vOTXX2c96LuZmZmDBg363//+Z4IxkuaFYpSQO/j7Izoaa9YAgFgMHx+IxRAI4OoKPh9ubuDx4O4OAN27u3btGuPm5sbn87mvrq6uAoFALBaXlZUtWLDg66+/njZt2nPPPWfZT0RMjUc3gxIAaWlpS5cujYiIWLx4saXHYklPPoldu+DmhqFDUVqKQ4fQpk0jm1q7dq1EIuncuXN2drajo6NRh0maF5piIgBw6dKlw4cP5+TkWHogzYJQiI8/xsWLTWrkX//6V79+/S5evPjee+8ZaVykmaIYJQBQWloKwMvLy9IDsaTDhzF5MlxdASA0FMeOwcenMe0cOHBAr9cLhUKZTMbn8+Pj48+dO2fcoZJmhWKUAIBcLgfg6elp6YFYjE6HuXPxxhvYu7duy+DBcHB47HZmzpw5evRomUwGIDQ09LXXXtNoNLNnz6azZy0YxSgBblWjthyjn3+Oc+fQoQMiI5vUDjehtHDhwqKiIgBr165t1arV0aNHv/jiC6OMkzRDFKMEuFWN2uxBfU0NVq4EgPfeg719k5qaOHHiuHHjysvL3377bQBubm7r1q0DsHnzcbncCEMlzRDFKAFsvhpdvx6FhejbF5MnA4Be36TWNmzY4OLisn379h9++AHAtGnTYmJO/vHHlnfeMcZYSfNDMUoA265Gy8oQHw8Aa9eCz4dOh9BQSCSorGxkg4GBgcuXLwcwb9686mo1gAULQoVCfP45Dh821qhJM0IxSgDbnqmXSlFaimHD8MwzAJCYiD/+wI4dsLNrfJvz5s0bMeJlb+/UNWscAHTujEWLwBj++U+o1UYaN2k26PJ7AgCenp4KhUIul9vacX1REbp0QXU10tIQFoaaGnTrhsuX8fXXmDq1SS2npyMsDEIhTp1Cz57QaNCvH86dw5o1sO1bHFogqkYJdDqdUqnk8/nu3E2OtmTLlhNCIXvhBYSFAcCGDbh8GX36YMqUprY8cCBiYqDRYPZsMAZ7e2zZAh4Pq1cjL6/pAyfNCFWjBHK53Nvb28vLq6SkxNJjMasLFy706tXLw6PzsWMZXbs6l5Whc2fI5ThwAM8+a4T2y8vRoweKivDZZ5gxAwBeeQWJiXjmGRw8aIT2STNB1Six3WvvFy9erNVqJ058smtXZwBbt/5dVobhw42ToQBcXfH++wAwfz5u3gSADz6Ajw9++gnffmucLkhzQDFKbHSaPj09/fvvv3dycnr33XcBXLt2bcWKoI4dJ65bV23EXqZOxbPPwsGh7kDeywtSKZydUV5uxE6IhVGMEhu9aHTRokWMsXnz5rVp0wbAihUrqqqq+vQRhIQ4Gbejzz7DuXN1514BzJiBtDT88gtKSwFAocDy5cbtkJgbxSixxWr04MGDhw4dcnd3X7BgAYC//vrrs88+EwgEq1atMnpfAQFwc7v9lseDmxtSUrBwIQBUV+PIEaP3ScyKYpTY3EWjjDFuWdXFixdzNfiSJUtqa2ujo6N79OhhnjGEhqKoCGlp5umNmBbFKLG5g/rt27dnZmYGBATMnTsXQEZGxnfffefo6MidJDWbjz7CvHnQas3ZJzEJeogIsbmZ+n379gGIi4sTiUQAqquru3XrNnbs2LZt25pzGF26YPRobN5szj6JSVCMEps7N+rj4wOgoqKCezt06NDs7GyNJZ5Jv2gRQkLg62v+nokx0UE9sbmD+lGjRgFYvnz5lStXuC1CoZCrTM2Dx0PnzgDg5IT330fXrmbrmZgExSixuWp01KhRkyZNUqlU8+bNM3/v1dUYMQIODqipAYDRoyGTmX8UxJgoRm2aWq3eunVrXl6el5eX7VSjADZs2ODu7v79998nJyebuev163HxIlJSmro+NGk+KEZtlEqlio+PDwwMnDVrllKp3LRpU4cOHSw9KPPx9/dfuXIlgDfeeMNwktQMysqwdi0ArFsHPv3ytRiM2BilUimVSg21Z79+/ZKSkvR6vaXHZW46nS4sLAzA/PnzzdbpO+8wgA0bZrYOiTnQCk82pKSkZOPGjR9//HFZWRmA8PBwiUQyduxYS4/LYrKysoKDgwH8/vvv/fv3N3V3d61tSloOS+c4MYcbN25IJBLDZHR4ePjPP/9s6UE1C9ws08CBA3U6nan7eu01BrCoKFP3Q8yNqtEWrqCg4MMPP/zPf/5TXV3N4/HGjBmzdOnSQYMGWXpczYVKperZs+eVK1c2b948e/Zs03V04QJ69QJjyM6Gue44JeZi6RwnppKXlxcbG+vg4ACAz+dHRkZmZGRYelDN0c6dOwG4urpevXrVdL08/zwD2KxZpuuBWAzFaAuUk5Mzffp0oVDIBWhUVFRubq6lB9WsjRs3DsDUqVNN1P7Jkyd79ZoxaJDclEFNLIZitEU5ffr09OnTBQIBAHt7++nTp1+4cMHSg7ICBQUFLi4uAH744QdTtP/000/j1gqnpOWhGG0hTpw4MXr0aO5EjZOTU2xsbGFhoaUHZU3Wrl0LoHPnzlVVVcZt+ccffwTg4eEhl8uN2zJpJmiKqSUoLi5euXLlpk2bXFxcoqOjJRJJQECApQdlZbRa7cCBA0+fPr106dK7Fm/ev3//lStXdDpdeXm5Xq9XKpWMMe6iMYVCAUCpVOr1+vLycp1Op1KpMjMznZ2duZ9ljIWEhGRmZq5bt27+/Pnm/1zEHCwc48QYEhMTAfTr14/qnaY4efIkn8+3t7c/e/Zs/e2Pe0lpSUmJ4We//vprAK1bt66srDT7ByJmQgvltQTc2iLDhw+3qfvijS40NHTmzJkymWz27NlHjhzh8Xjc9rFjxw4cOJDP57u5ufF4PHd3dwAeHh4A3Nzc+Hy+q6urQCAQi8VCodDFxYXbAUBtbe2yZcsArFy50pwrSBEzoxhtCWxtpTvTiY+P37t3b2pqamJi4iuvvMJtXLFiReNa27p168WLF7t16/bSSy8ZbYik+aEYbQlsbaU703Fzc1u3bt20adPmz58/ZswYboHn+zKcCdVqtRUVFbW1tZWVlRqNpqqqSq1W19TUlJWVLV++HIBUKuUuPiMtFf3fbQmoGjWiF198cdu2bSkpKSEhIZ07d37QhFJDmurfv/+AAQPGjx9v2hETS6MYbQmoGjWuSZMmpaWlXb58+fLlyw/ax3Am1M7OztnZ2d7eXiQSOTg4ODo6Ojk5OTg4iESisLCwGTNmmHPkxCIoRlsCW3tCsknpdLr169dXVlbOnTt34sSJ9SeU3N3deTweN6Fk6WGSZoRitCWwtUd7mtSXX3559uzZ9u3bf/DBB9yKBIQ8HC3A3RJQNWosGo2GWxV/1apVlKGkgagatXqM1f76q79W25W7K5w0xcaNG/Pz84OCgl588UVLj4VYDYpRq6fVyhn7y9HRz3C5OGkc7vlUAKRSKZ+elEQajP6uWD2tVg5AIKAj+qaKj48vLi4eOnToc889Z+mxEGtCMWr1dLpSAEIhzS81SXFx8fr16wFIpVJLj4VYGYpRq8dVo0IhVaNNsnz5cpVKNWHChCFDhlh6LMTKUIxaPa22FIBAQNVo4+Xn5//3v/8VCASrV6+29FiI9aEYtXo6HVWjTbVo0SKNRvPyyy/36tXL0mMh1odi1Opx1SidG220M2fO7Nixw9HRMS4uztJjIVaJLniyHK0W+/ahoAC9eiEiognNcDFK1WgjvfPOO3q9/vXXXw8MDLT0WIhVooeIWIhOh2efxRNPICQE+/ZBp4NEgv374eaGl19+rJZKSj5VqQ55e88Wi4eZaLAt2JEjR4YPH+7m5paXl0e3gZHGoWrUQvbuRbt2WL4cACIjMXgw1GrMmIHHvOq7puZcefnPWu3NiopfKUYfF2Ns4cKFACQSCWUoaTSKUQs5exbBwbffhoQgJwdDh8LLC56ed3z19KwYE6D3dhYIvIRCT6HQWyBwM/xcQUFMmzbrRKJgjeaBS7o9Wm0t8vPh7w9X1yZ8JOuzc+fOEydOtGrVKjY21tJjIVaMYtRCxGJUVNx+W1EBxqBQQKG4d9+rg/tUKLIMb3k8ARep3t4xPJ6guvqss3Oog0MntfpiVdUfQqH3rcD15PMbcJf9Dz8gLg5hYfjzT/TqhQ8/xN9/A0CHDmjRa7brdDruQUlxcXGGB3kS0gh0btRCcnLw2ms4ehT29lAoMHgwTpyAXg+5HKWldV9vvbgyV1styNfpSrXaEq22VKdTcm0EBKzy9JxSVLSsqiqzVatlOp3q8uV/1u+Ex3MQCj0dBO27zbG7o8jl/vP0RI8eGDoUJ07AwwMAoqLwj39AowGAyEg4Od137Evy86+p1Y58PoAVHTr42NmZ8k/KVLZu3Tpr1qwuXbqcPXvWzjo/AmkmWnK50az17o0ZM/Dkk+jYEXl5+OgjcI+TvN+aoW3ufMuYVqcr1WrlAoGnnZ1fhw7faLU3c3P7tmv3iYdHlFYr576r1Zbq9ZW1tdcEOicc/fv+w/j2W/ToUZehAMaPx/HjeNTdkBq9fmG7dl0fELJWobq6mnsY/Zo1ayhDSRNRjFrOrFmIiYFCcd/ofAgeTygU+gqFvgCqqjKcnPozpuHx7Fxdn3Nzm1B/T8bUWq1cX6nAryW3y9uSeq9dXFB/IXc7u7pS9FFyKioUtbUigSDIeg6HlUrlxYsX8/Ly8vLykpOTr1y5MmDAgEmTJll6XMTqUYxaFI/3uBl6F6Xyh6KiZYCgffvPeDz7e5p3sLMLgHsAHjSHX1aGt95CbS24iuzYMYSFNaTfv2tqlDqdl1DYPGNUoVD8fT/19/Hy8ho0aBCtLkiajs6NWrfKyvQrV+aLxU8GBKxqZBMJCUhJQVQUzp7FmTPYv/+RM0sL8vJmBgQ0h4N6rVZbWFiYl5dnKDM5lZWV9+4sEok63VJdXf3JJ5/4+/v//fffTs3ggxCrRtWoddNoCioqjtrZPfBx6o/25pt49lmcOoUxYyCVwhoe1paRkfHuu+/m5eVdunSptrb23h28vLw63alz586tWrWqv096enp6evpnn302d+5ccw2ctExUjVq3mzdlly/P9vaOaddOZrZOfykr6+vi4mWhy6FOnDixbNmylJQU7q2Hh0fHenr27Nm7d2/ucZ4Pt2vXrueff75t27YXL160t7/7fAghDUfVqHWzyJrNA1xcRp4509bR8XtLrIf022+/paSkPPfcc2vXru3UqZOjo+PD91coFPWP91944QVucfsJEyYEBQVlZ2d/+eWXr776qlnGTlomilHrZpF1SZRaLQMsNTWTnZ0NYNy4cfcuateQmSV/f38uRnk83qJFi1588cV///vfL7/8srBF32tATIr+6li3Ww9iMms1qtRqAbhZ6CwqF6NBQUHc24yMjDVr1nCVZlVV1b37Ozs71z9DOnjwYMO3Jk+evGLFivPnz3/77bfTpk0zz/hJy0Mxat1uHdSbtxrV6QC4WaJ802q1ubm5PB6vd+/e3Ba1Wr17927u9V3nSTnt27d/0GM+BQKBRCKJjo5es2bN1KlT6WmgpHEoRq1baWk3YLBO1+bRuxoPV426WiJGL1y4UFNT07FjR9dbq6j06dMnKSmJKzbd3Nwe/uP3+sc//rFq1apz587t2rXrhRdeMPZ4iU2gf36t2yuvxIeGpt24EfzoXY2n7qDeEjGalZUFoE+fPoYtYrE4KipqwIABjchQAHZ2dgsWLACwevVqumqFNA7FqHWTy4H734hvQnUH9ZY4N8qdGK0fo00XHR3dunXr06dP79+/34jNEttBMWrduHX1zByj5ZauRg3zS0bh4ODw9ttvA+AWKyHkcVGMWjGVChoNxGKY+eJxC54bFQrn9O8/Pyion3GbnTVrlq+v78mTJw8dOmTcloktoBi1YhY5ogegPXq0S26ua1mZmftVKrFnz+g//1zXuXNn47YsEonefPNNAGvWrDFuy8QWUIxasdJSADD/M4QOrV+//aWX7O+3UL9JZWWBMfTubZL7/ufOnevh4XH48OFjx44Zv3XSolGMWjFLVaNyuRyA+Z8Bl5UFAEadXrrN1dWVeyLTe++9Z5IOSMtFMWodLl6EXl/3urAQlZX44w8EB+PIEaxejbNnzTqY0tJSAJ5mz+/sbAAw6vTSHWJjY8Vi8Y8//pienm6qPkhLRDFqHSZNgkpV93rBAmRmIiQEO3bgyScREoKoKPONRKPRVFRU2NnZubg04Hl5RsVVo6aLUU9Pzzlz5oAKUvKYKEatVe/e+M9/cOOGufs1HNGbed14xuqKbtPFKIB//etfIpFoz5493JVVhDQExajV2LQJH36IDz/E+fMA4OCApUsxf765h8Ed0Zv/xGh+PsrLERAAnyYsUX0vvV4fGxt78OBB7q2vr+/MmTMZY8uWLdPpdMbsibRcFKNWo3t39OyJnj1huOlxwgQoFDhyxKzD4KpR858YNcX8kk6ni46O3rBhw7Rp01S3TpqMHz/ezs4uLS3Nz89v8uTJW7duvXbtmjF7JS0OxajVGDECo0Zh1Cj4+9/e+PHHWLwYAE6exKefwgw3hVuqGpXLIRbj1rpORqDVal955ZXExERnZ+ft27eLxWIAGRkZkyZNqq2tra2tlcvlO3bsmDVrVtu2bYcMGbJ69erMzEy6757cByPWoG9fVlZW93rKFHb0KAsOrnu7fDnr3p1168YANno0u3LFhMPIzMwMDw93d3fv0KHD1atXTdhTPbt3s6NHGWNMr2c7drCiIiO0qVarJ06cCMDNze23337jNh47doxb3yQyMrK6uvrChQsfffTRyJEjHRwcDL8v/v7+b7+9eceO2/87CKEYtQ7p6UyrrXt99iwrK2MnT9a9ra5maWksKYl5ezOAubkxmcz4Azh8+HBERAQXJc7OzgA8PDy++uor4/d0j8mTWceOTKFgjLFp025/8EarrKx85plnuI9w8lZzv/76K1eQTpkyRaPR1N+/qqoqJSUlNjY2MDAQwLBhhwEmELDgYBYXxzIymF5/e+erV1lhYd3roiImlzd1tKT5oxhtOa5fZxMmMIAB7LnnmLGKxdTU1BEjRnABKhaLY2Njs7Kyxo8fz20ZM2aMqcvSyZPZkiVszhzGjBGjFRUV3Mfx8/M7c+YMt3H//v3cY5anTZtWW1v7kB/PysrasEE+bBgTCuv+qAHWrh2bPZslJ7PKSrZ0KQsMZCoVY4wtX87M8g8NsTCK0ZYmKYl5ejKA+fiw775rfDt6vT45OXnQoEFcXHp5ecXFxZWWltbrKMnDwwOAj4/Pd03p6VEmT2bZ2eypp9jJk02NUYVCwT1EpFWrVjk5OdzG5ORk7rB91qxZOp2uwU2xpCT2yivMz+92njo5sbffZhMnsvnzGaMYtRkUoy1QQQGLiKj7xZ49u1z+mAeWOp0uOTk5OLhuKWgfH5+4uLiy+50LLCgoMBzpR0VFlZSUGOkTMMaYXs927WLfflsXozk5bMgQNnUqO3mSffMNu/Owu0FKS0tDQ0MBtGvX7uLFi9zGb775xs7ODsD8+fP19Q/OH0dODpNKWUQECw5mS5eynTtZeDg7c4Zi1FZQjLZMej2TyZirK+vbN9bPz2/37t0N+SmdTpeUlNS9e3cuGdu2bZuQkFBVVWXY4fTp0zdv3ryzI71MJuPuaPL399+zZ0/TB6/TseRkNmAAA1irVuyFF1h2NmOMLVjAPDxYfDwDWGAgk8luny9+pOvXr3OrlHbt2rXw1snLL7/8UiAQAJBIJE0fNmNMrWZLl7Lvv2d//MGefJJi1FZQjLZkeXmlTzzxBJeJr776qlKpfNCearU6MTGxS5cu3M7t27dPSEiorq427HDq1KmoqCgej7dw4cJ7f/zvv/8eNmyYoSytf+z/WDQa9vnnrGvXulI6MJBt3Mhefpnl5jLGmErFundnmzezHj3qdujfnx048OhmL1++zH20Hj16GM7kbt68mXuG3YoVKxo32vviYpQx9vrrLCiIYtQmUIy2cFy1KBKJAAQGBv7888937VBTUyOTydq0qXsoXqdOnWQyWf1plqNHj3Lz2twc/bvvvvvIjtq1a3fo0KHHGqdazRITWefOdfnYoQNLSGD1YvwOOh1LSmIdOtTtPGQIS019YMv5+fmdOnUC0L9/f0MpvXbtWgA8Hu+jjz56rHE+kiFGlUoWEEAxahMoRm1Cbm7uwIEDueCIiYlRqVSMMZVKlZCQ0KpVKy4ig4KCEhMTtfWOk1NTUyMjI7nvuri4xMbGFj3qos2zZ8/e29HDVVZWbt2aGhBQl4k9e7KvvmrQ0bpazWQy5utb94MRESwr6z67paamikSiwYMHK7hrphiTSqXcCDdu3Pjobh7T1at112YVFrJPP6ULnmwCxaitqK2tXbVqlb29PYCOHTu++uqrhhs6Bw0alJycXH+CJSUlJSwsjPuuq6urRCJp+DxVbW2tVCrlOurQocORI0cetKchxwUC+/btNX36sMTExzjdeasRJpUysZgB7KmnDkZFReXn59+1z/Hjxw2BvnTpUgACgWDbtm2P19PjqK5mDg6Mz2eNPb1BrAnFqG3Jzs4eMGCA4RL68PDw5ORkw3e5OfqQkJBHztE/UlZWVv/+/QHw+fzY2Niampr635XL5XFxcdz1UgDCwsIOHsxp7Dw5Y4xdvcreeEMjFvsBEIlECxcuNNSeBnq9ft68eQDs7e137NjR+M4a5oknGMD27jV1P8TyKEZtjlqt5u6IT0pKMmzk5uh79OjB5Zqfn59UKq2srGxKRxqNRiqVcpcT9ezZMz09nTFWXFwcFxfn7u7OdXRXjjfR+fPnuXkw7g4lqVRquMxAq9VGR0cDcHBw2LVrl7F6fIglSxhQdwEpadkoRm0RV4oajnMVCkXHjh25XOvQocOWLVvuKh6b4vjx4926dQNgZ2cXHh7OzUEBGDVq1LFjx4zVS32///674bar1q1by2Sympqal156iStUf/rpJ1N0yklPZ//+d939Yz/9xAAWEmK63khzQTFqc9RqNXdgW3/js88+27Fjx7vm6I2lurpaIpHweLzWrVvzeLzIyMiTTb8x/lEOHjzInb4AwC044urqmvqQGX1jGDuWASwxkTHGKiuZvT0TCGgRk5aPYtTmFBUVcXdD1t9YXFzc8PsgGyc8PByAKSbHH0Sv1yclJXXq1KlNmzZisfj48eOm7vH99xnAoqPr3g4ezAC2f7+puyUWRuuN2pz7rrvs4+PDXYtuOlqtFoDhHlMz4PF4UVFRp0+fLikpqaioMPrT7e81fDiA2wtpc3ckmHldbWJ+FKM2x2zrLufm5u7cufM898wTyz1P1MXFJSwsjDFmhgfQ9+sHd3fk5aGwEKAYtRkUozbHbE8B2bNnz6RJkxITE+v3a/5l8wFwN6oeMX2eCQQYMgQAUlMBIDwc9vZQKmsqKqpN3TWxIIpRm2O2OKtffur1+rKyMj6fb7jUyZzMFqMAhg0Dn4/MTBUAsRhDhow/d84pLS3VDF0TS6EYtTlmO7iuX/aWlZXp9Xp3d3duRSUzGzx4sKOj45kzZ8rKykzd19NP54nF7fftG8i9DQnpCuDo0aOm7pdYEMWozTHbudH6Za+lnifKcXR0DAkJ0ev1Zjk92k6vLz1//jx3RQRXCP/666+m7pdYEMWozTFbotUvey14YpQzfPhwmOW4XigUcgvsc5E9dOhQgUCQnp5eVVVl6q6JpVCM2hyLVKOWmqY3MGdVWP9UrJubW9++fTUazYkTJ8zQNbEIilGbY+ZqtP5BvQWr0SFDhtjb2586dUqpVJq6r7tmtMw5wUUsgmLU5pgt0RQKBQBuGSeLV6MikSg4OFin06WlpZm6r4EDBzo7O+fm5hYXF4Ni1AZQjNoc8yRaeXm5RqMRi8XcwqNmO5PwEGaLM3t7+/fee2/79u3cEjBDhw7l8/knTpyoqakxddfEIihGbY55YvSu3LTsTD3HnFVhbGzs5MmTuRj19PQMCAjQ6XTjxo3btm3bjRs3zDAAYk5CSw+AmFVlZWVNTY1IJHJycjJpR3flZnOoRp944gmhUJiRkaFSqcRisXk6ZYy9+eabV65ccXV1TUlJSUlJAdCzZ8+xY8dGREQMHz5cKKTfQatH1ahtMfO1982qGnVxcenfv79WqzXbpDlj7I033li/fr29vX18fPymTZvGjBkjEolyc3Pj4+NHjhwZEBAwffr0b77ZXlpqnhERk6AYtS0WuRPUnP0+nDmP63U63YwZMzZt2iQSifbu3Tt79uw5c+bs27dPLpenpKRIJJIePXrcvHnzq6++Wr78e19fhIRg4UIcOwbGzDA6YkwUo7blvgfX3ISycd2VmxafqeeYLUY1Gs3//d//JSYmOjs779271/CEagCOjo4RERFSqTQ3N/fPP//88MMPhw+fKxTijz8QH4+hQ9GmDWbOxPffQ6UCgF9+QUhI3eujR7FiBd58E2fO1LW2fj127TL1pyGPQDFqW+49uL506VKXLl1mzZpVUVFhxI6aZzXK3VP0+++/m/SeIrVaPWXKlO+++87d3T0lJeXpp59+0J7dunV76623ZLJhJSXYtQszZ6JNGxQV4dNP8cIL8PbGiBHIzoZKhbg4AKiqglyO68dkHSIAAAcBSURBVNdhmPMvLUV5uek+CmkQilHbwqUb99A3TlpaWnV19datWwcMGGDEayqHDh26ZMkSrvrTarUqlUooFLq6uhqr/ca57z1FhYWFYWFhK1euzMjI0Ov1Teyiqqpq7Nixu3fv9vT0/Omnn7gbQx/JxQUTJmDrVhQWIi8PCQmIiABj+OUXiESYMAGnTuHUqdv7X7uG/Hzk58P0a62QBrDw6vvEvM6fPz9q1CiBQCCRSDQaDbcxOzvb8DDkmJiYJj4Q9F7cJT6+vr7GbbZx3nrrLQDLli0zbNmyZYvh18Hb2zsqKioxMbG0UQ+YV6lUTz31FAA/P7+srKwmDrW0lCUns+RkJpGw06dZeDjbv5+98QabMoVNmMBiYlhMDAsOZtu2NbEf0lQUozYnNjaWq0ZDQ0Nzc3O5jfd9GLKx5ObmAujevbsR22y03bt3Axg2bJhhS1VVFTfnwz3BlCMQCIKDg+Pi4rgStSEtKxSKsLAwAG3btr1w4YKxBszFKGPszTfZ1Kl1MXriRN134+IoRi2PYtQWpaamdurUCYCjo6NUKtVqtdz2kydPdu/eHYBQKJRIJGq12ijdffDBBwC6du1q6qfmNYRcLufz+XZ2dkePHr13PHl5eQkJCREREdzNVxw/P7/p06cnJSUplcoHNXvjxo2+ffsCaN++/cWLF404YEOMKpWsdev7x+i337ING5jxnopNHg/FqI1SKpUxMTFcWTp48ODz589z27mHIXOLKwcFBWVmZja6C71en5ycHBoailt31g8ZMsSIZVqjLVmyJDAwEICXl1dUVJRMJrt27dpd+yiVyu+++y46OrpVq1aGPHVwcBg5cuSVK1fu2vnatWu9e/cG0K1bt8LCQuOONjf39rNFf/6Z7dnDtm1jly7VbfnxR3bwIDt+nO3dy/77X+P2TBqKYtSmHThwoE2bNgCcnJykUqmhOvvtt9+6dOkCwM7OLi4uzlCuNpBWq/3mm2+CgoK49PH394+Ojvbz8wPg4uKyefPmBh4mm4hOp3v99dc7duxY/xA+PDx8zZo1mZmZ944tJydHKpVGRETY2dmJxeK7ivSCggLuz6pnz55FRUVm/Bx3+PRT9ssvlurc1lGM2jqFQhETE8OlSUREREFBAbe9srJSIpFwT10eNGjQuXPnGtKaRqNJTEzkzgwACAwMTEhIqKqququjkSNHXr582YSfqmHy8vJkMllkZKSDg4MhUn19fblDeIVCcdf+JSUlR44cqb8lPz+fi+MBAwbcvHnTjGO/w4ED7JNPLNU5oRgljDHG9u3bxx29urq6ymQyw/aDBw9y5apIJNq3b99DWlCr1YmJiVxdxp0iTEhIqK6uvmu3HTt2+Pj43NuRZVVWVqakpMTGxrZt2/auElUqlT5oluncuXOtW7cGEB4eXlZWZv5hc86cYc88wyQS9uOPlhqCraMYJXVu3Ljx/PPPcwkyatQowxlA7iyqt7f39evX7/uDNTU1MpmMS1sAnTp1kslktbW1D+ro+vXr48eP53YeO3bstQc0ayn3nWVq3759TExMUlJSeXk5t1tOTg73D8+wYcMMG4ltohgld0hKSuLuNXJ3d69fLd43Q1UqVUJCgmESJigoKDExsYEnUpOSkjw9PT0CAp4/fXqn5Q6HH6K0tHT79u0vvfSSr6+vIU+dnJxGjRr1zjvvcDdojR49mjtlQWwZxSi527Vr18aNG8elxqRJk+57yk+pVEqlUsO9nv37909KSnrciaPCwsJ3U1ODMzKCMzIW5uWVPbiAtTjDLBO3rh2fz7e3t3/++eeNdU0YsWo8RuvJkPv54osvXn/9dZVK5evru2XLlokTJ3Lbb968uWnTpo8//ph75nt4eLhEIhk7dmyjO/pBLo8vLKzS6TyFwkXt2j3l7m6cD2AaxcXFBw4c+OuvvyIjI4ODg2m1UAKAYpQ8UEFBQXR09C+//AIgKipq1apVn3/++YYNG7h1PcLDw1esWDFixIimd3RNo1lx6VKGSgUgwsNjcWCgK8UTsR4Uo+Rh9Hr9xo0bFy1aVFVV5ejoWFNTw+Pxxo0bt3Tp0pCQECN2xIBdJSUfFRZW6/XednZL2rXrIRJdVqu577ZzcPCyszNid4QYEcUoebQLFy7MmzevR48e165dW7x4seG6eqMrqKlZfulSdmUlDxjv41OsVge5uAAY6ubWXSQyUaeENBHFKGle9MC3xcV75fJILy8w9qKfn6VHRMgjUIyS5kjH2M6Skp8VCq4InRMQ4MintXFJM0Un8klzJODxAPQSiUZ7egKwr7fONCHNDcUoab587Oy60ilR0uzRgRIhhDQJnRslzZRSq2WAO11ASpo9ilFCCGkSOqgnhJAmoRglhJAmoRglhJAmoRglhJAmoRglhJAm+X8U1V9jMIYuMgAAAjB6VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHu/b+09BiDgAWJGBgiQB2IlIG5gZEvQANLMLGwJFiCakQUhAKUVDJBoJgSNrg7TIFwmYlGBoRRdhlNBAeR+KMWuABFmZodoQNAQCSYMCQ4FkH//M8JoAQWQOCsLNwNHAoNgBhODuAIjUwYTo3gCE3MCE68CM2cGE7NEAgsrAysbA5scAztHBhO7cAK7mAKHCAMnVwKneAIXdwYTN08Cj0QGE4+kAi9fBhOvQAKfVAK/VAYTv3SCgHQGk6BQgqAog5BwBpOYHIOMHIOsHIMICysjEzOnOBu7sJAgAwcbFzePBDMnG58Uv7QArzgsghjkG6S793eYX9gP4nhwstvf/c1gD2Jz32FwaM81BbNzt2s5RKqpgNXYzvI/MLt0ogOI/bYn7MAqbWcw+3PFtAMeAZJgNkNq9oEfqjvA6tkZRA+k3/MAs6N+nLIXFbsOZvO++2Hfd8DjAIituDbCYW5JMpht+KXPQfOzApi9RU3PIYyBCWI+T7tDjyQrmM0c1+KgsHQqmB3255u9WE8wmP2QYeb+wNvuYL2ZT5UObN5WCGZvCC860HHJGswO5+U7cFreDOyvzaU2ttX7a8Hii7PnHnDbLQF226GdbXYdjJVg9pGyZgfv6nYw245/r4PFcog5HpvmOjTsiwTbe+WEhkOrxBQwm0s15IBmhRfYfMFLJw9cZ2sEs70/zTzwxikNzBYDAFHjlN45N0kPAAACMnpUWHRNT0wgcmRraXQgMjAyMC4wOS4xAAB4nJ1WS27cMAzd+xS6wAgkRVHissj0AxRJgBToHbrqprl/qc/IHiQBYg4MDJ9pPvMvy+vr3/hlC+33cv35519YP7puW0gYEocA716qGn4TADT7C0aoUockJKVxQDQthIfwEcXx2oZFppKnBKn6WCgCNr+bbYHq9IWiSGksF4jCSC6WS4rEIw6OmbN4WVKmHlGKwJp9LGzZoDRiS5qdLClKqTAqbaH5snsxD6jiyG6p7MtLwJhrLrPrKrCXRZnriA2TOLvOalR7fY0lZwYfC0eWkkaGMrJ7AgohzllImLy+EMHsFyjqnCNuOc1DkiL+GpHKzDNkH4t1CWpOs9JEvuy2yvCNpRRnvzTbKjL4NLF7jgh1Tk9BPObl25m9CywwvFK567rPs9h+UdS5MbPKcaafzvhCkuZm0ELFx2JdB5VGzcGWhI8lR4WxpVqNCL2+KPWNab3LcwOfZ7HzKPXN0OZo8p1maSfJ2ipFQQ8sz29Z8AMWsRkUHXMJcOfLCRaO1Yo0bKvenWq/3rK88yGydW4db+gAjY5uoJ2YU2P30tLQUZM68wK4Aw4Iy4YD5aUxSRYwqSxQ2jfTDdTuG90AwUHTumACDbRs7I14BLujdrt9gww2k3ARmNR8owWWbxYM7hoDy1G7TTuQDmiBujSlg6mpAVeuDRAtoD248ZhFtueA9AAS7OAxhIcf37uNPWNTGpra/pvm69N1+w9/eaUC90aVpwAAAXh6VFh0U01JTEVTIHJka2l0IDIwMjAuMDkuMQAAeJwlkjtuIzEQRK+yoQRQRP8/cCjAoTfY0HA0uU7gw281hQGImQJfdbE4z+fz3+377+Pn/l6/Lr5un/fr9njJhfXS64VH73iBcN2+7i98zJaL//zeHrrFNHvZdvPg9QFFXdSXbrJ2g2I7SSSWbG13OUoxlS7a1W3eb4wtA1I2VQek2EpRvXgTFb255tZeD9reEVQHjCyy9eBtWjEgBkmxzrYsC7OjCbcff2YThQTfAjtkSARS0JZQ1hiyU6JGckkrB+ikZQBlE6tN+qRKOkoKM+OEpCy5PmyLkOoI2WOD5FLEaMXQhY+AOVYoLjKMxyMUI0eQbIRhIO0FRMnfcyPSfMKBEJ4tXp7nAEWIPYxNi2gF9ok5oMtnj253HV/bFqm8UImzFcrxjcr5KK1CJy7uBzGnIy/MnLbQn9qxFsEMVEMWxHTMG4fh0zN+hCF1Z067c0M593LcLWXdf/8DMjWCK33TS9MAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f1a6312bd50>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f0bde24c0d0>"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10907,17 +11168,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3de1hU1d4H8O/MMFyG4SqIAiIiggpeCNOUTE3SSPAYSpaXLr4FnjqimTnkDU1NkjI0Tck0eTv5FJ18C7spphlmimACCqIgXrgEAgPDfW7r/WMjcfCSwsxsmPl9np4eZs+evX6D+W3ttfZeW8AYAyGEkM4S8l0AIYT0bBSjhBDSJRSjhBDSJRSjhBDSJRSjhBDSJRSjhBDSJRSjhBDSJRSjhOiSWq2Wy+V1dXV8F0IMx4zvAgjpLo4cwezZuHgRzs548kn89BP+7/+QkQGNBnV1UKtRXw+VCo2NaGlBUxOAqTU1JU1NTS0tLY2NjSqVqr6+njtUYGBgVFTUK6+8wusXIgZCMUrIX6ZPx7p12L699eUXXyA5+a479+p1varqYoeNIpHI1tY2Pz8/MjLS2tp6zpw5eiuWdBcUo6TVpUuXLC0tXV1dzcxM978KPz+UlCA7u/VleDiGD4eZGaRSiMWwtoa5OaysYGkJS0tIJMnm5gKJRCIWi6VSqZmZmY2NDffBTz/9dMGCBUuXLg0JCXFwcODt+xCDENA99YTj7+9/4cKFnJwcf39/vmvhx5EjOHcO//M/iIxEXR1++qnzh2KMBQcHHz16dOHChTt37tRdjaQ7oikm0qq6uhqAo6Mj34Xw5rffcPgwzMwwaRKKirp0KIFAsHPnTgsLi48//vjkyZM6KpB0UxSjpJWJx6hajf37kZqKL7/Eq68iP7+Txzlw4MDmzZsB+Pj4LFu2TKvVLly4UKVS6bJW0s3QST0BgPr6ehsbG2tr67a5ZlOzaxf++U/4+OD8eYjFnTzIpUuXhg4dKhAIMjMzhw8f3tLSMmLEiPz8/Pj4+GXLlum0XtKNUG+UACbfFW1qwsaNALBxY+czFICPj8+//vUvtVr9yiuvaLVaCwuLbdu2AYiNjS3q4jAB6cYoRgkAVFVVAejVqxffhfDjgw9QXIxRozBzJgB05dr59evXu7u7p6enf/zxxwCmTJny3HPPqdXC998v01GxpNuhGCXArd6oacaoXI733weAuDgIBGhuxvDhmDsXCkVnjmZjY7N161YAMpmstLQUwJYtHwwZUrFjx7gDB3RZNuk+KEYJcKs3apon9e+8g+pqTJmCyZMBYMcOXL2KnBxIpZ08YHh4eFhYmEKhWLkyDkCfPi5RUVYA/vUv1NbqrGzSfVCMEsCEe6MlJfjoIwgEeOcdAKitxaZNAPDuuxB24S/Hhx9++Pjje1NSth4+DABRURg3DmVlWLtWBzWT7oZilAAm3BvdsaOwuRnPPIPAQACIj0dVFcaPR0hIlw7bv3//J598qbpa8NpraGqCUIhduyAW48MPcfasTgon3QjFKAFMdaY+Ly9v82bfwYPnbNigBlBRgW3bACAuTgcHf/11jByJgoLWfu6wYVi8GBoNoqKg0ejg+KT7oBglgKnO1K9YsUKj0UyYYO/tbQZgyxZ5XR1mzMC4cTo4uJkZEhMhFGLzZuTmAsC6dRgwABkZoLtDjQzFKAFMsjeanp7+7bffWltbr169GkBBQcEHH/QdOzZ+40atrpoYPRqRkVAqsXAhGINEgh07AGDlSpSU6KoRwj+KUQKYZG80JiaGMfb666/37dsXwKpVq5TKlqFD84cO1eVfik2b0KcPiopw4wYAhITg6afR2IijR3XYCOEZ3QxKAGDIkCEXL17My8sbPHgw37UYwg8//DBt2jQnJ6eCggI7O7usrKyHHnrI3Nz80qVL/fr1021bGRnw9cWtJfRQUoKKCgQE6LYRwifqjRLAxGbqtVrtqlWrAKxYscLOzg7Am2++qdVqFy1apPMMBTBq1F8ZCsDNDVVV6NULN28CwJNP6rxBYmgUowSMMblcLhAITGSB4f379//xxx9ubm4LFy4EcPz48dTUVHt7e5lMZrAauGX2iXGgGCVQKBRqtdrW1lbclWU5egilUrl27VoAGzdutLKyAvD1118DWL58uSGHhv38IBb/tcw+6dEoRolpndGLxeJp06bZ2tqGhYVxW7Zt23bo0KHFixcbuJI1a7B+vYHbJHpBMUpMa5qeMZaRkaFQKNa1O6meMmWKRCIxTAFaLTIzAcDBQQfL7JPugGKUmNZFo0KhMDExUSwWb9++/fTp04Yv4MsvERODM2cAdGmZfdJ9UIyaOsZYamoqTKY3CsDf33/JkiVarfa1117TGPbGTJUKq1cDwNSphmyW6BfFqOnSarUHDx4cPXr0+++/P3r06KVLl/JdkeGsXbt2wIABmZmZO7j7igwlMRGFhfD1xfPPG7JZol8Uo6ZIrVZ/9tln/v7+06dPz8jIcHNzmzt3biC3xpFpkEgkXICuWrWquLjYMI3W17c+qiQuDmZmhmmTGAQjpkSpVCYlJfn4+HB/+v37909ISGhqauK7Ln6Eh4cDmDlzpmGaW7eOAWz0aKbVGqZBYiB0M6ipaGlpSUpK2rBhw40bNwB4eXnJZLKXXnrJFK4VvZuysrIhQ4bU1tampKS0Xf+kJ5WVGDgQCgWOHsWkSXptihgc3zlO9K6+vj4hIcHV1ZX7E/f3909KSlKr1XzX1S1wz03y8PCoq6vTa0OLFzOATZum10YIPyhGjZlCoUhISHBxceECdMSIEUlJSRqNhu+6uhGNRjNmzBgAy5cv118rRUUaCwsmFLJz5/TXCOENndQbp8rKyu3bt2/btk0ulwMICgqSyWShoaECgYDv0rqdzMzMMWPGCASCM2fOjBw5Uh9NvPjigoKCR0aMmLNjR2efk0e6M75znOhYeXl5bGysra0t9+cbFBSUkpLCd1HdXXR0NIDRo0fro6uenZ0tFArNzc0LCwt1fnDSHVCMGo9r165FR0dzy20ACA4O/v333/kuqmdQKBTu7u4AEhMTdX7wadOmAVi8eLHOj0y6CTqpNxJardbHx6ewsFAoFIaHh69cuVJP56fG6uuvv541a5adnV1eXh63Hj5HrVbX1NQoFAqtVltbW8sYq6mpAcCNltTW1mq1WoVCodFo6urq1Gr1+PHjudzknDhxYvz48VKptKCgoG2QmhgbvnOc6MacOXOkUumkSZNyc3P5rqWn4q55mjt3bvuNmdw6Ivdt2bJl7T8eFBQEYN26dYb9KsSgqDdqJIKDg3/++efU1NTg4GC+a+mprl+/7ufnV19f3/7XmJ+fHxQUZGdnJxAI7O3tAXCLW9vb2wsEAltbW5FIZGNjY2ZmJpVKxWLxmDFjJk6cyH3222+/nTFjhrOzc2FhoU37FfCJcaFb0oyESS12pyceHh6rV6+WyWT//Oc/c3JyLC0tAfj6+lZWVnbiaBqNZuXKlQDWrFlDGWrc6J56I2FSi93pz9KlS0eOHFlQULBp06ZOfLy2tlYul1+7du3KlSsbN268cOGCp6fnK6+8ovM6SbdCJ/VGQiqVNjQ01NXVSaV0ZWKXpKenjx07ViQSLVy4UCKRqFSq+vp6tVpdV1en0WjuNtdUU1Nz+18la2vrXbt2zZs3j4evQQyIYtQYKJVKCwsLc3PzlpYWvmsxBqNHjy4tLS0pKXnQD3JDpdwgqbW19ddffz1w4EChkM75jByNjRoDGhjVobKystzc3IaGhhdffHHw4MFmZmY2NjYikcjW1lYoFN5trsnOzo7i0mRRjBoDk3omnb69/fbbDQ0N4eHhn376Kd+1kJ6B/v9pDLj5JeqNdt3ly5f37NkjEonW00M7yX2j3qgxEIvr5s4d5uo6gO9CerxVq1apVKqXX3556NChfNdCegyaYjIGlZV7rl172cnpf/r3/4TvWnqwzMzMhx9+2MLC4tKlS/369eO7HNJj0Em9MVCrqwCIRDQ22iUxMTGMsejoaMpQ8kAoRo2BRlMNwMyMxkY775dffjly5Ii9vb1MJuO7FtLDUIwaA643amZGvdFOYozFxMQAiImJoQseyIOiGDUGt2KUeqOdlJycfPr0aVdX10WLFvFdC+l5KEaNAXdST2OjnaNWq9euXQtg7dq1EomE73JIz0MxagyoN9oVu3fvvnjxoo+Pz0svvcR3LaRHohg1BhSjndbU1LRx40YA77zzjpkZXUZNOoNi1Bio1XRS30lbtmwpKSl5+OGHw8PD+a6F9FR0+b0R0JaXb9FoalxdN/BdSQ8jl8sHDhwol8uPHDkyefJkvsshPRWdxfCEMchkUCigUmHQIMTE4OBBqNWoqMDnn8PREb16wdERjo5wckKvXi2BvbW9bc3MeolEjkKhVdthmpsvlpSsEItdGWv6+0abm1FdDbkc1dWorsaZM4iKgglfar5hwwa5XD516lTKUNIV1Bvlyf79KC7G8uUAEB2NWbPw2GMAsGgRtm+/fferPwdV2f3G/SwUWnF5ambmaGUVYG0d6Og4l3urtvZ7pfKaWi3XaKrb/m158ob7qiqRXIWm26LW1RVZWXBy0tfX7MZKSkoGDRrU3NyckZHx0EMP8V0O6cGoN8qTrCyEhrb+PHYssrJaY/TNN/HMM6iqQnU1qqpa/6muFttIrawUanW1RlOl1TYplcVAMYA+fWLq63+7du0VMzNHV9cN168vVCqLOzTVbzNEpXcpo7QUCoVpxuiqVauampqee+45ylDSRRSjPBk2DOnpGD8eANLT8Y9/tG738ICHx+27uwFut37WahvV6mqNplqtrpJIAm1tpwIoLl5eV3fMymqYWl2j1da3/6y46p6VbN2KlpaOYwtPP33v8tMVio9KS30kEnuR6FU3t3vv3A1dvHjx3//+t1gsfvvtt/muhfR4FKM8mTMHy5fjtdegUsHTE7ceyXs/hEKJubkEcAdQU/ONQnFIIDBXqcqsrUd7e//AmKa5+UJDw6n6+lMNDaebmy82DNXaH7/LsUQiuLqCu4s8Ohq//oqwsPssY6K9/Yt9+tx/2bxraGgovGXPnj1qtfrVV1/19vbmuy7S41GM8kQoxHvvdf0w9vYzhEJJff0JB4dZIpE9AIFAZGU13MpquJNTJACNprbp81/Zxu8E10uQno6bN//r8xYWGDeu9ef2Ywv34ZeamlKl0t/aenr3Wy5aLpdfuc3Vq1e1Wi23g1AotLGxmTlzJr91EuNAMdrjKRSHy8vfF4nspNLxt78rEtlJ3cLw0a0+5pUrOHUKp0/j9GlcvIiZM+88tnAfukNvlDFWXFxceBvumZ0dWFhYDBgwYODAgQMHDszOzv7ll1927979+OOPG75sYmRopr7Hu3r1paqqfZ6ee3v1evB7GbVaLF+OpqbWsYUVK+7zc+kKRW5jI18xeurUqXfeeaegoKCoqKi5ufn2HWxtbQf+N29vb3d397anzpWVlXl5ealUqgsXLvj6+hq2fGJsqDfa491as7lTZ9adHVvIami41NiY29Aw1Nq6M+12QVpa2saNGw8dOsS9dHBw8LrNgAEDBALBPQ7St2/fF198cdeuXXFxcfToOtJFFKM9Hi9rNp+tqztTVxfRu7chG+UcP3780KFD06dPf/vttwcOHCiVSu+9f3l5eWFhYUFBAXe+//bbb3t5eQF466239u7d+9lnn61cuZImmkhXUIz2eLys2Vyr0QCwF4kM2SgnJycHQHh4+IgRIzq8JZfLL1y4kJub2zatdPnyZYVC0X6f2bNnczHq4eExZ86cffv2vffee7t27TJY/cT4UIz2eLws71SrVgOw5WNJJC5Ghw8fzr08duxYfHx8YWHh1atXlUrl7fs7Ojq2HyQNCAhoe2vlypWfffbZ3r17V6xY4XGny3UJuR8Uoz0d02jkgEAkcjBkqwq1GoCdwWO0paXl8uXLZmZmQ4YM4bbU1dX9+OOP3M+3j5P6+fn17dv3bkfz9vaOiIj44osvtmzZkpCQYIgvQIwRzdT3bE1NLWfOzLe0bBw9+juDNapkbNzZs2KB4HeD30aZmZk5atQoPz+/8+fPc1tu3rx58uRJrqdpZWV174/fLjc3d9iwYebm5leuXLlH4BJyD7TeaM9WVmYxYULys88aLkNx64ze8F1RANnZ2QCGDRvWtsXZ2fkf//iHv79/JzIUwNChQ6dPn97c3Lx161adVUlMDMVoz1ZdDQAGvo2IrzN63BoYbR+jXbdmzRqBQLB9+/bKykodHpaYDorRnq2qCgAM/Ejg1t4of9P0bfNLOhEQEDB16tSGhobtd1qikJC/RTHas/HTG1UqwdM0fXm5GLrujQJYs2YNgISEhDveRUrIvVGM9my89EYLv/nmj0ceadqxw6CtAuXlyMn5wcNDo/OLk8aOHTtx4sTa2tqdO3fq9sjEFFCM9my89EYrKyu1arVULDZoq0BWFgB4egrvfaNn56xatQrA+++/X19f/7c7E9IexWjPxktvtLq6GoCjgVsFsrMBQKfjon+ZPHlyUFBQVVXV7t279dIAMV4Uoz2buTmcneHsbNBGuRjtZfBlRnNyAEDX46J/eeuttwBs3ry56faHVhFydxSjPVt8PCoqMGeOQRutqqoCf71R/cXotGnTRo0a9eeff+7bt09fbRBjRDHaMxw5gri41p+Dg1u39OrVupj9k08atBheeqNqNfLyIBDAz0/HR25/I19MTAyAuLi4O96eT8gdUYz2YNOnY906HtrlpTean4+WFnh5wdZWl4ctKip65JFHLly4wL0MDw/39/e/fv366tWrKUnJfaIY7TG++QYLF2LhQpSXt27x84NY3Hqqa0i89Eb1Mb+Um5sbFBSUnp6+du3ato3u7u729vabN292cHB44okntm7deuPGDV22SowOxWiPMWMGdu3Crl1wcflr45o1WL++9efVq/Gf/xiiEl5m6rn5JR3G6Llz5yZOnFhWVjZhwoS9e/cC0Gq1UVFRP/30U0NDg7e3d2Nj45EjR5YsWeLh4REQELBixYoTJ05oNBqdVUCMBcVoz+bggEmTUFSE9HRs3IiICMyZ03oxqT5kZWXNmzdPLBZLpdKtW7e2PWjTAB57DK+9hkmTdHO0zMzM4ODgmzdvhoSE/PjjjzY2NhqNZsGCBbt375ZIJN99993ly5evX7+emJg4Y8YMqVR67ty5TZs2jR8/vnfv3kuWFP/v/3Z8xCoxaYwYBa2WJSYyqZQBzMWFffONjo9/4sSJkJAQ7r8Zc3Nz7odJkyYVFRXpuCX9S0tLs7W1BRAWFtbc3MwYa2lpmTVrFgBra+uff/65w/4qlSotLU0mkwUGBlpY2FpbawEmFLLAQCaTsbQ0ptHw8TVIt0ExalSKitikSQxgAIuIYNXVOjhmWlpaaGgol5tSqTQ6OrqkpOT77793dXUFIJFIEhIStFqtDlq6i9RU5ujIKioYY2zq1K4e7dixY9zjm5599lmlUskYa25unjFjBgB7e/uTJ0/e++OFhX9u28aefJJZWrb+ngHWuzd74QX25Ze6+YWTHodi1Nhw3VJrawYwDw+Wmtr5Q6Wmpo4dO5YLUBsbG5lMVlVV1fauXC6fN28e9+6UKVNu3Lihg+rvXAZ78UX22muMdTlGv//+e0tLSwDz5s1Tq9WMsYaGhieeeAKAo6Njenr6/R+qsZGlpjKZjA0e/Feezpuny8QnPQXFqHHKzWWjRzOACQRs7dqj9fX19/9ZrVabkpLy8MMPcxHp5OQUGxsrl8vvuHNycrKTkxMAOzu7xMREHZXPGGPV1WztWrZpE0tNZfHxbMkSlpXFpk5lSiV76y1WUvLAB0xJSbGwsACwcOFCjUbDGKurq5s0aRIAFxeX7OzsTpd64QKLj2ePP84+/FBniU96EIpRo6VSsbg4NmZMpUAgHDBgwLFjx/72IxqNJiUlpe2hb717946Li2toaGjbIT09ff/+/R0+9eeff3InxQCeeuqpkk4k3H8rL2cxMczGhgHM1pZ9+y2Lj2fV1WzWLDZ1KvvwQwYwiYTJZOwu2X4H+/fvNzMzA/Dmm29yW+Ry+SOPPALAw8Pj0qVLXayZ0yHxiYmgGDVy585lcQ8iFgqFy5Yta2pquuNuSqUyKSnJ19eXS8P+/fsnJCQ0Nja27XDixInQ0FCBQGBnZ3fHnmlycrKDgwMAZ2fn//znP52r9s8/mUzGJJLWc+SgIHbkSGs2McZ27GA+PuziRRYRwQQCBjBHRxYXx9qVeWcff/yxUCgEIJPJuC3l5eXcr8XT07OwsLBz1d6OK7Ut8YmJoBg1fiqVKi4uTiwWAxgyZEiHEcCWlpakpKSBAwdyATpgwICEhARu/ppz+PDhxx57jHvX1tY2Jiampqbmjg2VlpZOmzaN2zMiIqKysvL+i7x6lUVHMyur1oGI0FB26tS99k9PZ48/3pq2bm4sMZGpVHfec+fOndzCeu+++y63payszN/fH4Cvr29xcfH9F/m32hL/gw+Yuzu7y++JGBuKUVNx7tw5rv9lZmYmk8laWlrq6+sTEhLc3Ny44PPz80tKSlK1S6PU1FTutJcL0A5TTHek1WoTExO5qXAXF5dv7uPCq/z8/EWLNpmbM+4qotmzWVbW/X6pn35iAQGtYTpkCEtJUdx+zcCpU6dsbW0TEhK4l9euXfP29gYwdOjQ0tLS+23pAQUHM4AdOKCnw5PuhWLUhDQ1Nb3xxhvc6W3//v3bbkMKDAw8cOBAWwBxI6SjRo3i3nV2dr7HFNMdXblyZeLEiW3d0uq7XAeUk5Mzf/58bshy7NiSiAiWl/fAX0qrZcnJbNAgBrCAgDdGjx599OjRDvuUl5e3FTZgwADuKz9QZ/lBxcYygC1erL8WSDdCMWpyTp486enp2adPHwDjxo1LSUlpH6DJyclDhgzhEtDFxaXDFNP947qlEomEm8M5cuRI+3fPnDkzY8YM7lzbwsIiKiqqqOhqV76UUsk++aTS5dZ9siEhIefOneuwT15eHtf1fvTRR2tra7vS3N86dowBbORIvTZCuguKUVO0Z88e7mLPti3cFJOPj0/7Kaa7zUfdv9zcXO7CKYFAEBkZWVdX1zZVxQVoZGSkDi84ra+vj4uLs7e351qMiIi4fPky99Yff/zh7OwMYMKECQqFQlcttqdQsB9+YL/9xhhjTU3M0pIJhezvRkGIMaAYNUVbt24FsGjRorYt3Dqb3KzLvn37VHebr3lwKpVq/fr13P2j3FR+28X8befaulVVVSWTybjL7MVicWRk5KFDh7j1qEJCQhr/dl6/sz75hAFs5szWl+PHM4ClpOipNdKNUIyaotjYWACxsbFtW65duxYYGPjFF19o9HN/eE5Ojqenp4eHh0QiuZ+pqq67evXqCy+8wA0EcyEeHh7e0tKivxYvX2YAc3Zm3BjJqlUMYG+8ob8GSXdBKzyZIm7d5fYLhnp4eGRkZMyePZvLHZ3z9/d/+umnr1+/HhMTExcXZ4BF9vr3779v376srKzx48fb2dl5enp++eWXbYuq6IO3N9zccPMm8vIAYMIEADh+XH8Nku6CYtQU8bJgaE1NDYC266sMw9/ff//+/Tdv3pTL5fp4LHMH3PW1XHSOGwdzc/zxB2pr9d0s4RnFqCm6vTeqD4WFhfPmzYuPj+de8vU8UXd3dy8vr9ra2izuOff61L4HKpEgMBAaDX77Td/NEp5RjJoiwyTalStXPv/888OHD3Mv+XqeKIAJEyYAOK7/E2zuYtnjx8E9JS88/MywYQtPnIjVd7uEXxSjpsgwidahz8tXbxQGjFFfX4SGpvbqtSA/Px/AsGHVOTmJR48e0ne7hF8Uo6bIMCf1HUZgee+NpqWlGeCpJxLJJxcufPrrr8cBBAUFicXizMzMuro6fbdLeEQxanLUarVCoRCJRLa6fVTxbTqEtVwuB08x6unp2b9//+rq6vPnz+u7rfY9X6lUGhAQoFarf//9d323S3hEMWpyuLvjHRwc9HRtU5v2vVGFQqFUKm1sbPR6ydE9cItUGeC8novRY8eOtX9pgHYJjyhGTY5hzug7NMTLJVbtGSzOhg4d2rt377KyssLCQkO2S3hEMWpyDDbV0z46DZbdd8PF2a+//sq4SXS9EQgEjz76KG5F56OPPioSic6cOdPY2KjXdgmPKEZNjsGmerpVb9Tb27tfv343b97M4+4x0qcJEybY2dlxtxvY2dmNGDFCqVSeOnVK3+0SvlCMmhyDdQzbd3t5740C4DqJv/zyi74bioyMrKqqWrp0KfeSW3r1q6++0ne7hC8UoybHYCf17bu9PF402sZgw5SWlpYikajtZXl5uYuLy65du/r06fP8889/9dVXtXR/qHGhGDU5hjm/1mq1NTU1AoGAW/2Tx4tG23C9QgMMj7ZhjC1ZsuTzzz+vqqpycnIqLy//7LPPnnnmGRcXlylTpnzwwQeXLl0yTCVEryhGTY5hEq2mpkaj0djb23PPCOF9bBSAr6+vq6vrn3/+aZjwYoxFR0dv3brV3Nw8OTm5oqLi7NmzGzZsGDdunFqtTk1NXbp0qa+vr7e3d2xs2U8/obnZAEURvaAYNTk83sLE70k9bg2PGuC8XqPRLFiwYPv27RKJ5ODBg08//bRAIAgICFi5cuVvv/1WUVGRnJwcGRnZt2/fkpKq997rGxICR0c88QTefRf5+fqujugYxajJuX2YMjMzc//+/bpt5Y431PPbG4WhhkdVKtWzzz67b98+a2vrgwcPTpkypcMOjo6OERERiYmJxcXFv/6a/sYbCAxEczOOHEFMDAYPhp8f3nwTx45BpdJrpURHeF00mvBg5MiRAM6ePcu9bG5u9vPzAzBz5syKigpdtfLDDz8ACAkJ4V5yD2o+efKkro7fOdzNoH379m2/8caNG/n5+bpqorm5ecaMGQDs7e0f6PuWlbG9e1lEBLOza31kNMBeeIE5OjLuj2XqVMYYS01lmza1fmTyZF1VTbqEeqMmx9zcXCQSZWRkcC8tLCxiY2MdHBy+/vprf3//AwcO6KSVkJCQ2traffv2cS+7SW+0wy1GnJ07d/r6+np5eUVFRX311Vf19fWdPn5jY2NYWNg333zj4OBw6NOts8gAAAYCSURBVNChsWPH3v9n+/TBSy8hORmVlTh2DMuXw98fo0Zh+nSsW9fpiohB8J3jxNDS0tK4P/r58+e3PX3+6tWrkydP5rZHRETo/Bnu3Nn9zZs3dXvYTggPDwewZ8+eti1r1qxxcnJq+xshkUhCQ0M/+uijoqKiBzpyXV3d448/DsDFxSU7O1sn1aamsvh4tmQJy8r6qzc6ZgyLimJRUczfXyeNkK6iGDU53BPkpVIpgD59+qTcenZlh+3ffvutrlrUaDQikUggEOjwgaOdxj0V9fnnn2+/UaPRZGRkxMXFBQUFtV+xxcvLKzo6OjU19W+fhSeXy7mBi379+l26dElX1XIxWl3NZs2ik/rui2LURF25coVb9IjrlrY9uv3KlSvcPEyH7Z2WnZ09Z84cW1tbGxubxMTELhfeVdyjRGxsbCIiIpKSkqqrqzvswE2jz58/n7vilWNtbR0aGpqYmHjjxo3bj1lRUcGNOHt6ehYUFOiwWi5GGWM7djAfn9YtHWL0hx/Yu++yxYt12Cx5MBSjpkuj0SQkJFhYWADo37//zz//zG3nuqUSiaTD9gd1+vTpsLAw7kFyYrGYy6OwsLCysjLdfYkHptFo2laxA2BmZjZ+/PhNmzZlZWV12FOtVmdkZMTGxgYGBrY9Di8sLKzDbmVlZcOGDQPg6+t7x5A1jFdf5atlQjFq8i5cuDBq1CgAAoEgMjKyvr7+3tvvR1paWmhoaFs/Ljo6uri4ODk5mRshtbe3571bWlhYmJiYGBoayv1fhNO7d+/58+cnJyfX1NR02P/atWs7d+4MCwvbu3dvh+2DBg0CMHTo0NLSUgN+g/8SH8/S0/lqnFCMEsZUKlVcXBy3oLKXl9fx48fvvf0e0tLS2qaqpFJpdHR0+3ApKyubPn069+6sWbO6w4xTQ0NDSkpKZGSku7t7+y5qUFBQXFxcRkbGPT5bVFTk5eUF4KGHHuLxu2zdyubOZR98wLRavkowdRSjpFV2dnZAQAAAoVAYHR3d3NzMbT979ix30vrUU0/d4+OpqaljxozhYsjW1lYmk90+7MhJSkqysbHhen8HDhzQ/TfprPPnz8fFxQUHB7cNQQAYMGBAZGRkcnJyXV1d+53z8vLc3NwABAUF3d57JSaFYpT8RalUxsbGcqsT+fn5nTlzhtve3Ny8evXqOw78aTSalJSUwMBALnScnZ1jY2P/NlaKioq4hUIAxGzZolCrdf9luqCqqqrtZs22PLWysgoODo6Li8vLyzt//jz31oQJE7o+C0d6OopR0tGpU6cGDx7MndvKZLK7Xeuj0WiSk5OHDBnCpYyLi0tcXFxDQ8N9tsJNZPXq02d6ZuaUrKzj3bJDp9FoTp06tWbNmlGjRrXNMnHjFQBCQkIaGxv5rpHwT8AMtWgY6UGamprWrVsXHx+v1WqHDx+elJTEXdDDUSqVX3zxxYYNGy5fvgzA09NzyZIlUVFRlpaWD9pQkVy+vrw8u6FBADzt7LzE3V2i5wftdVplZeWxY8cOHjz43XffzZ49u6Gh4ZNPPuHrCX2kW6EYJXd18uTJF154oaCgQCwWr1ixYvXq1Wq1Oikpaf369cXFxQC8vLxkMtmCBQu41fA6Rwt8WVHxYXGxkjFXc/M1np6jbGx09yV0T61Wt7S0WFtb810I6S4oRsm91NXVLVu2bPfu3YyxQYMG1dTU3Lx5E8CIESNWrFgxa9YsXT2l+UpT09qrV3MbGwXA005Or/frZ9Vdu6WEdEAxSv7e4cOHX375ZXt7+5ycnJEjR3IB2n6sUCc0jP27vHxXaamKMTcLi7WengFSqW6bIEQfKEbJfampqWlsbLx06VLbDLue5DU2xl69eqWpydvK6nV3952lpT4Sib1I9Kqbm17bJaTTKEZJt6NkLLG0dLKDQ71andvY+GKfPnxXRMi9UIyS7itdofiotNRHIvG3tp7O9wNICLmbzk+wEmIAE+3tqTdKujmaDCWEkC6hk3pCCOkS6o0SQkiXUIwSQkiXUIwSQkiXUIwSQkiXUIwSQkiXUIwSQkiXUIwSQkiX/D+nUHyIUL8PtwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvigqKuIubqCiZFpiae4les1rJSV6s7BuGm6Ja3fQFnO5inVLql8ZZiqaaWTmEm6EC4hpICKKigwzw8DADDPz/P44OJIrwswchvm+X718zRzOPM8zph+/5zznPEfAGAMhhJD6EvI9AEIIsW0Uo4QQ0iAUo4QQ0iAUo4QQ0iAUo4QQ0iAUo4TcceEClMqa1xcvQqfjdTTERlCMEnLHtGl47bWa1//6F4qLeR0NsRFivgdASOOi1+PHHzFiBABUV6O4GOXl0OuhVsNgQFkZjEaoVACg1eZoNEeUSiVjjPtVpVIZjcaysjKDwTBr1qwePXq4ubnx+3WIFVCMEvI3K1bgxRfx1FMAsHcvXn/9gXsOHlzy22/TH/TTzMzMfv36/d///Z8FxkgaF4pRQv6mWTPExGDFCgCQSuHnB6kUIhHc3SEUwsMDAgE8PQGgUyf3Dh1iPTw8hEIh96u7u7tIJJJKpUqlcs6cOd98883kyZOfe+45fr8RsTQB3QxKAKSnpy9cuDAqKmr+/Pl8j4VPTz6J7dvh4YGBA1Faiv370bJlPZtauXJlfHx8SEhIVlaWs7OzWYdJGheaYiIAcPny5QMHDmRnZ/M9kEZBLMYnnyA3t0GN/Pvf/+7Zs2dubu77779vpnGRRopilABAaWkpAB8fH74HwqcDBzBhAtzdAaBvXxw5Aj+/+rSzd+9eo9EoFouTkpKEQmFiYuL58+fNO1TSqFCMEgCQy+UAvL29+R4IbwwGzJyJN9/Erl01W/r3h5PTY7czbdq04cOHJyUlAejbt+9rr72m0+lmzJhBZ8+aMIpRAtyuRu05Rr/4AufPo21bjBzZoHa4CaW5c+cWFRUBWLlyZfPmzQ8dOvTll1+aZZykEaIYJcDtatRuD+qrqrB0KQC8/z4cHRvU1Lhx40aPHl1WVvbOO+8A8PDwWLVqFYANG47K5WYYKmmEKEYJYPfV6Jo1KCxEjx6YMAEAjMYGtbZ27Vo3N7ctW7b8+OOPACZPnhwbe/yPPza++645xkoaH4pRAth3NapUIjERAFauhFAIgwF9+yI+HhUV9WwwKCho8eLFAGbNmlVZqQUwZ05fsRhffIEDB8w1atKIUIwSwL5n6mUylJZi0CA88wwAJCfjjz+wdSscHOrf5qxZs4YMednX9/CKFU4AQkIwbx4Yw7/+Ba3WTOMmjQZdfk8AwNvbW6FQyOVyezuuLypC+/aorER6OiIiUFWFjh1x5Qq++QaTJjWo5ZMnEREBsRinTqFLF+h06NkT589jxQrY9y0OTRBVowQGg0GlUgmFQk/uJkd7snHjMbGYvfACIiIAYO1aXLmC7t0xcWJDW+7TB7Gx0OkwYwYYg6MjNm6EQIDly5GX1/CBk0aEqlECuVzu6+vr4+NTUlLC91is6uLFi127dvXyCjlyJKNDB1elEiEhkMuxdy+efdYM7ZeVoXNnFBXh888xdSoAvPIKkpPxzDPYt88M7ZNGgqpRYr/X3s+fP1+v148b92SHDq4ANm26pFRi8GDzZCgAd3d88AEAzJ6NW7cA4MMP4eeHn3/Gd9+ZpwvSGFCMEjudpj958uQPP/zg4uLy3nvvAbh+/fqSJaHBweNWrao0Yy+TJuHZZ+HkVHMg7+MDmQyurigrM2MnhGcUo8ROLxqdN28eY2zWrFktW7YEsGTJEo1G0727KDzcxbwdff45zp+vOfcKYOpUpKfj119RWgoACgUWLzZvh8TaKEaJPVaj+/bt279/v6en55w5cwD89ddfn3/+uUgkWrZsmdn7CgyEh8edtwIBPDyQloa5cwGgshIHD5q9T2JVFKPE7i4aZYxxy6rOnz+fq8EXLFhQXV0dExPTuXNn64yhb18UFSE93Tq9EcuiGCV2d1C/ZcuWzMzMwMDAmTNnAsjIyPj++++dnZ25k6RW8/HHmDULer01+yQWQQ8RIXY3U797924ACQkJEokEQGVlZceOHUeNGtWqVStrDqN9ewwfjg0brNknsQiKUWJ350b9/PwAlJeXc28HDhyYlZWl4+OZ9PPmITwc/v7W75mYEx3UE7s7qB82bBiAxYsXX716ldsiFou5ytQ6BAKEhACAiws++AAdOlitZ2IRFKPE7qrRYcOGjR8/Xq1Wz5o1y/q9V1ZiyBA4OaGqCgCGD0dSkvVHQcyJYtSuabXaTZs25eXl+fj42E81CmDt2rWenp4//PBDamqqlbteswa5uUhLa+j60KTxoBi1U2q1OjExMSgoaPr06SqVav369W3btuV7UNbTrFmzpUuXAnjzzTdNJ0mtQKnEypUAsGoVhPSXr8lgxM6oVCqZTGaqPXv27JmSkmI0Gvkel7UZDIaIiAgAs2fPtlqn777LADZokNU6JNZAKzzZkZKSknXr1n3yySdKpRJAZGRkfHz8qFGj+B4Xb86ePRsWFgbgxIkTvXr1snR3d61tSpoOvnOcWMPNmzfj4+NNk9GRkZG//PIL34NqFLhZpj59+hgMBkv39dprDGDR0Zbuh1gbVaNNXEFBwUcfffTpp59WVlYKBIIRI0YsXLiwX79+fI+rsVCr1V26dLl69eqGDRtmzJhhuY4uXkTXrmAMWVmw1h2nxFr4znFiKXl5eXFxcU5OTgCEQuHIkSMzMjL4HlRjtG3bNgDu7u7Xrl2zXC/PP88ANn265XogvKEYbYKys7OnTJkiFou5AI2Ojs7JyeF7UI3a6NGjAUyaNMlC7R8/frxr16n9+sktGdSENxSjTcrp06enTJkiEokAODo6Tpky5eLFi3wPygYUFBS4ubkB+PHHHy3R/tNPP43bK5ySpoditIk4duzY8OHDuRM1Li4ucXFxhYWFfA/KlqxcuRJASEiIRqMxb8s//fQTAC8vL7lcbt6WSSNBU0xNQXFx8dKlS9evX+/m5hYTExMfHx8YGMj3oGyMXq/v06fP6dOnFy5ceNfizXv27Ll69arBYCgrKzMajSqVijHGXTSmUCgAqFQqo9FYVlZmMBjUanVmZqarqyv3WcZYeHh4ZmbmqlWrZs+ebf3vRayB5xgn5pCcnAygZ8+eVO80xPHjx4VCoaOj47lz52pvf9xLSktKSkyf/eabbwC0aNGioqLC6l+IWAktlNcUcGuLDB482K7uize7vn37Tps2LSkpacaMGQcPHhQIBNz2UaNG9enTRygUenh4CAQCT09PAF5eXgA8PDyEQqG7u7tIJJJKpWKx2M3NjdsBQHV19aJFiwAsXbrUmitIESujGG0K7G2lO8tJTEzctWvX4cOHk5OTX3nlFW7jkiVL6tfapk2bcnNzO3bs+NJLL5ltiKTxoRhtCuxtpTvL8fDwWLVq1eTJk2fPnj1ixAhugef7Mp0J1ev15eXl1dXVFRUVOp1Oo9FotdqqqiqlUrl48WIAMpmMu/iMNFX0f7cpoGrUjF588cXNmzenpaWFh4eHhIQ8aEKpLk316tWrd+/eY8aMseyICd8oRpsCqkbNa/z48enp6VeuXLly5cqD9jGdCXVwcHB1dXV0dJRIJE5OTs7Ozi4uLk5OThKJJCIiYurUqdYcOeEFxWhTYG9PSLYog8GwZs2aioqKmTNnjhs3rvaEkqenp0Ag4CaU+B4maUQoRpsCe3u0p0V99dVX586da9OmzYcffsitSEDIw9EC3E0BVaPmotPpuFXxly1bRhlK6oiqUZvHWPVvvzXT6ztwd4WThli3bl1+fn5oaOiLL77I91iIzaAYtXl6vZyxv5ydA0yXi5P64Z5PBUAmkwnpSUmkzujPis3T6+UARCI6om+oxMTE4uLigQMHPvfcc3yPhdgSilGbZzCUAhCLaX6pQYqLi9esWQNAJpPxPRZiYyhGbR5XjYrFVI02yOLFi9Vq9dixYwcMGMD3WIiNoRi1eXp9KQCRiKrR+svPz//f//4nEomWL1/O91iI7aEYtXkGA1WjDTVv3jydTvfyyy937dqV77EQ20MxavO4apTOjdbbmTNntm7d6uzsnJCQwPdYiE2iC574o9dj924UFKBrV0RFNaAZLkapGq2nd99912g0vvHGG0FBQXyPhdgkeogITwwGPPssnngC4eHYvRsGA+LjsWcPPDzw8suP1VJJyWdq9X5f3xlS6SALDbYJO3jw4ODBgz08PPLy8ug2MFI/VI3yZNcutG6NxYsBYORI9O8PrRZTp+Ixr/quqjpfVvaLXn+rvPw3itHHxRibO3cugPj4eMpQUm8Uozw5dw5hYXfehocjOxsDB8LHB97ef/vV27t8RKDR11Uk8hGLvcViX5HIw/S5goLYli1XSSRhOt0Dl3SrUVUFpRJKJRQKKJUoLUVGBsaPR2QkqquRn49mzeDubplv20ht27bt2LFjzZs3j4uL43ssxIZRjPJEKkV5+Z235eVgDAoFFIp7973Wv3u54qzprUAg4iLV1zdWIBBVVp5zde3r5NROo8ksK/vFYFCa/tPrFQaD0v+Dq77fagXa6vsM49NP8eGH+PRTRETgzz/RtSs++giXLgFA27Zo0mu2GwwG7kFJCQkJpgd5ElIPdG6UJ9nZeO01HDoER0coFOjfH8eOwWiEXI7S0ppfb7+4OlNfKco3GEr1+hK9vtRgUHFtBAYu8/aeWFS0SKPJbN58kUZz6ubND+/qR6xAj6EPHUmrVjhzBl5eABAdjX/+EzodAIwcCReX+35iQX7+da3WWSgEsKRtWz8Hh4b9XvBj06ZN06dPb9++/blz5xxs8yuQRqIplxuNWrdumDoVTz6J4GDk5eHjj8E9TvJ+a4a2/PtbxvQGQ6leLxeJvB0cAtq2/Vavv5WT06N58/ckkp6VldmM6U07i1WPGklISE2GAhgzBkeP4lF3Q+qMxrmtW3d4QMjahMrKSu5h9CtWrKAMJQ1EMcqf6dMRGwuF4r7R+RACgVgs9heL/QFoNBkuLr0Y0wkEDr6+r/r5/cto1Gg0pyoqTmg0JyoqTlR7X6r2h0Pxg5urnYYODjWl6KNkl5crqqslIlGo7RwOq1Sq3NzcvLy8vLy81NTUq1ev9u7de/z48XyPi9g8ilFeCQSPm6F3Ual+LCpaBIjatPlcIHAEIBRK3Nwi3dwiuR30+hL97v0OX6cjNxcnTqCk5O4m/voL1dXgKrIjRxARUZd+L1VVqQwGH7G4ccaoQqG4dD+19/Hx8enXrx+tLkgajs6N2raKipNXr86WSp8MDFxWpw9cuoQTJ2r+O3MGs2fDwwNpaYiOxrlzOHMGe/Y8cmZpTl7etMDAxnBQr9frCwsL8/LyTGUmp6Ki4t6dJRJJu9sqKyv/+9//NmvW7NKlSy6N4IsQm0bVqG3T6QrKyw85ODzwcep3Cw5GcDD+8Q8AYAxcLfbsszh1CiNGQCaDLTysLSMj47333svLy7t8+XJ19X2uQPDx8Wn3dyEhIc2bN6+9z8mTJ0+ePPn555/PnDnTWgMnTRNVo7bt1q2kK1dm+PrGtm6dZLVOf1Uqe7i5+fB0OdSxY8cWLVqUlpbGvfXy8gqupUuXLt26deMe5/lw27dvf/7551u1apWbm+vo6GjhUZOmjKpR28bLms293dyGnjnTytn5Bz7WQ/r999/T0tKee+65lStXtmvXztnZ+eH7KxSK2sf7L7zwAre4/dixY0NDQ7Oysr766qtXX33VKmMnTRPFqG3jZV0SlV7PAL6mZrKysgCMHj363kXt6jKz1KxZMy5GBQLBvHnzXnzxxf/85z8vv/yyuEnfa0Asiv7o2LbbD2KyajWq0usBePB0FpWL0dDQUO5tRkbGihUruEpTo9Hcu7+rq2vtM6T9+/c3/WjChAlLliy5cOHCd999N3nyZOuMnzQ9FKO27fZBvXWrUYMBgAcf5Zter8/JyREIBN26deO2aLXaHTt2cK/vOk/KadOmzYMe8ykSieLj42NiYlasWDFp0iR6GiipH4pR21Za2hHobzC0fPSu5sNVo+58xOjFixerqqqCg4Pdb6+i0r1795SUFK7Y9PDwePjH7/XPf/5z2bJl58+f3759+wsvvGDu8RK7QP/82rZXXkns2zf95s2wR+9qPjUH9XzE6NmzZwF0797dtEUqlUZHR/fu3bseGQrAwcFhzpw5AJYvX05XrZD6oRi1bXI5cP8b8S2o5qCej3Oj3InR2jHacDExMS1atDh9+vSePXvM2CyxHxSjto1bV8/KMVrGdzVqml8yCycnp3feeQcAt1gJIY+LYtSGqdXQ6SCVwsoXj/N4blQsfr1Xr9mhoT3N2+z06dP9/f2PHz++f/9+87ZM7AHFqA3j5YgegP7QofY5Oe5KpZX7Vamwc+fwP/9cFRISYt6WJRLJW2+9BWDFihXmbZnYA4pRG1ZaCgDWf4bQ/jVrtrz0kuP9Fuq3qLNnwRi6dbPIff8zZ8708vI6cODAkSNHzN86adIoRm0YX9WoXC4HYP1nwJ09CwBmnV66w93dnXsi0/vvv2+RDkjTRTFqG3JzYTTWvC4sREUF/vgDYWE4eBDLl+PcOasOprS0FIC31fM7KwsAzDq99DdxcXFSqfSnn346efKkpfogTRHFqG0YPx5qdc3rOXOQmYnwcGzdiiefRHg4oqOtNxKdTldeXu7g4ODm5ma9XgHcrkYtF6Pe3t6vv/46qCAlj4li1FZ164ZPP8XNm9bu13REb+V14xmrKbotF6MA/v3vf0skkp07d3JXVhFSFxSjNmP9enz0ET76CBcuAICTExYuxOzZ1h4Gd0Rv/ROj+fkoK0NgIPzqvER1XRiNxri4uH379nFv/f39p02bxhhbtGiRwWAwZ0+k6aIYtRmdOqFLF3TpAtNNj2PHQqHAwYNWHQZXjVr/xKgl5pcMBkNMTMzatWsnT56svn3SZMyYMQ4ODunp6QEBARMmTNi0adP169fN2StpcihGbcaQIRg2DMOGoVmzOxs/+QTz5wPA8eP47DNY4aZwvqpRuRxSKW6v62QGer3+lVdeSU5OdnV13bJli1QqBZCRkTF+/Pjq6urq6mq5XL5169bp06e3atVqwIABy5cvz8zMpPvuyX0wYgt69GBKZc3riRPZoUMsLKzm7eLFrFMn1rEjA9jw4ezqVQsOIzMzMzIy0tPTs23btteuXbNgT7Xs2MEOHWKMMaORbd3KiorM0KZWqx03bhwADw+P33//ndt45MgRbn2TkSNHVlZWXrx48eOPPx46dKiTk5Pp70uzZs3eeWfD1q13/ncQQjFqG06eZHp9zetz55hSyY4fr3lbWcnS01lKCvP1ZQDz8GBJSeYfwIEDB6KiorgocXV1BeDl5fX111+bv6d7TJjAgoOZQsEYY5Mn3/ni9VZRUfHMM89wX+H47eZ+++03riCdOHGiTqervb9Go0lLS4uLiwsKCgIwaNABgIlELCyMJSSwjAxmNN7Z+do1VlhY87qoiMnlDR0tafwoRpuOGzfY2LEMYAB77jlmrmLx8OHDQ4YM4QJUKpXGxcWdPXt2zJgx3JYRI0ZYuiydMIEtWMBef50xc8RoeXk593UCAgLOnDnDbdyzZw/3mOXJkydXV1c/5ONnz55du1Y+aBATi2t+qwHWujWbMYOlprKKCrZwIQsKYmo1Y4wtXsys8g8N4RnFaFOTksK8vRnA/PzY99/Xvx2j0ZiamtqvXz8uLn18fBISEkpLS2t1lOLl5QXAz8/v+4b09CgTJrCsLPbUU+z48YbGqEKh4B4i0rx58+zsbG5jamoqd9g+ffp0g8FQ56ZYSgp75RUWEHAnT11c2DvvsHHj2OzZjFGM2g2K0SaooIBFRdX8xZ4xo0z+mAeWBoMhNTU1LKxmKWg/P7+EhATl/c4FFhQUmI70o6OjS0pKzPQNGGPMaGTbt7PvvquJ0exsNmAAmzSJHT/Ovv2W/f2wu05KS0v79u0LoHXr1rm5udzGb7/91sHBAcDs2bONtQ/OH0d2NpPJWFQUCwtjCxeybdtYZCQ7c4Zi1F5QjDZNRiNLSmLu7qxHj7iAgIAdO3bU5VMGgyElJaVTp05cMrZq1Wr16tUajca0w+nTp2/duvX3joxJSUncHU3NmjXbuXNnwwdvMLDUVNa7NwNY8+bshRdYVhZjjM2Zw7y8WGIiA1hQEEtKunO++JFu3LjBrVLaoUOHwtsnL7/66iuRSAQgPj6+4cNmjGm1bOFC9sMP7I8/2JNPUozaC4rRpiwvr/SJJ57gMvHVV19VqVQP2lOr1SYnJ7dv357buU2bNqtXr66srDTtcOrUqejoaIFAMHfu3Hs/funSpUGDBpnK0trH/o9Fp2NffME6dKgppYOC2Lp17OWXWU4OY4yp1axTJ7ZhA+vcuWaHXr3Y3r2PbvbKlSvcV+vcubPpTO6GDRu4Z9gtWbKkfqO9Ly5GGWNvvMFCQylG7QLFaBPHVYsSiQRAUFDQL7/8ctcOVVVVSUlJLVvWPBSvXbt2SUlJtadZDh06xM1rc3P077333iM7at269f79+x9rnFotS05mISE1+di2LVu9mtWK8b8xGFhKCmvbtmbnAQPY4cMPbDk/P79du3YAevXqZSqlV65cCUAgEHz88cePNc5HMsWoSsUCAylG7QLFqF3Iycnp06cPFxyxsbFqtZoxplarV69e3bx5cy4iQ0NDk5OT9bWOkw8fPjxy5Ejup25ubnFxcUWPumjz3Llz93b0cBUVFZs2HQ4MrMnELl3Y11/X6Whdq2VJSczfv+aDUVHs7Nn77Hb48GGJRNK/f38Fd80UYzKZjBvhunXrHt3NY7p2rebarMJC9tlndMGTXaAYtRfV1dXLli1zdHQEEBwc/Oqrr5pu6OzXr19qamrtCZa0tLSIiAjup+7u7vHx8XWfp6qurpbJZFxHbdu2PXjw4IP2NOW4SOTYpo2ue3eWnPwYpztvN8JkMiaVMoA99dS+6Ojo/Pz8u/Y5evSoKdAXLlwIQCQSbd68+fF6ehyVlczJiQmFrL6nN4gtoRi1L1lZWb179zZdQh8ZGZmammr6KTdHHx4e/sg5+kc6e/Zsr169AAiFwri4uKqqqto/lcvlCQkJ3PVSACIiIvbty67vPDljjF27xt58UyeVBgCQSCRz58411Z4mRqNx1qxZABwdHbdu3Vr/zurmiScYwHbtsnQ/hH8Uo3ZHq9Vyd8SnpKSYNnJz9J07d+ZyLSAgQCaTVVRUNKQjnU4nk8m4y4m6dOly8uRJxlhxcXFCQoKnpyfX0V053kAXLlzg5sG4O5RkMpnpMgO9Xh8TEwPAyclp+/bt5urxIRYsYEDNBaSkaaMYtUdcKWo6zlUoFMHBwVyutW3bduPGjXcVjw1x9OjRjh07AnBwcIiMjOTmoAAMGzbsyJEj5uqlthMnTphuu2rRokVSUlJVVdVLL73EFao///yzJTrlnDzJ/vOfmvvHfv6ZASw83HK9kcaCYtTuaLVa7sC29sZnn302ODj4rjl6c6msrIyPjxcIBC1atBAIBCNHjjze8BvjH2Xfvn3c6QsA3IIj7u7uhx8yo28Oo0YxgCUnM8ZYRQVzdGQiES1i0vRRjNqdoqIi7m7I2huLi4vrfh9k/URGRgKwxOT4gxiNxpSUlHbt2rVs2VIqlR49etTSPX7wAQNYTEzN2/79GcD27LF0t4RntN6o3bnvust+fn7cteiWo9frAZjuMbUCgUAQHR19+vTpkpKS8vJysz/d/l6DBwO4s5A2d0eCldfVJtZHMWp3rLbuck5OzrZt2y5wzzzh73mibm5uERERjDErPIC+Z094eiIvD4WFAMWo3aAYtTtWewrIzp07x48fn5ycXLtf6y+bD4C7UfWg5fNMJMKAAQBw+DAAREbC0REqVVV5eaWluyY8ohi1O1aLs9rlp9FoVCqVQqHQdKmTNVktRgEMGgShEJmZagBSKQYMGHP+vEt6+mErdE34QjFqd6x2cF277FUqlUaj0dPTk1tRycr69+/v7Ox85swZpVJp6b6efjpPKm2ze3cf7m14eAcAhw4dsnS/hEcUo3bHaudGa5e9fD1PlOPs7BweHm40Gq1yerS10Vh64cIF7ooIrhD+7bffLN0v4RHFqN2xWqLVLnt5PDHKGTx4MKxyXC8Wi7kF9rnIHjhwoEgkOnnypEajsXTXhC8Uo3aHl2qUr2l6E2tWhbVPxXp4ePTo0UOn0x07dswKXRNeUIzaHStXo7UP6nmsRgcMGODo6Hjq1CmVSmXpvu6a0bLmBBfhBcWo3bFaoikUCgDcMk68V6MSiSQsLMxgMKSnp1u6rz59+ri6uubk5BQXF4Ni1A5QjNod6yRaWVmZTqeTSqXcwqNWO5PwEFaLM0dHx/fff3/Lli3cEjADBw4UCoXHjh2rqqqydNeEFxSjdsc6MXpXbvI7U8+xZlUYFxc3YcIELka9vb0DAwMNBsPo0aM3b9588+ZNKwyAWJOY7wEQq6qoqKiqqpJIJC4uLhbt6K7cbAzV6BNPPCEWizMyMtRqtVQqtU6njLG33nrr6tWr7u7uaWlpaWlpALp06TJq1KioqKjBgweLxfR30OZRNWpfrHztfaOqRt3c3Hr16qXX6602ac4Ye/PNN9esWePo6JiYmLh+/foRI0ZIJJKcnJzExMShQ4cGBgZOmTLl22+3lJZaZ0TEIihG7Qsvd4Jas9+Hs+ZxvcFgmDp16vr16yUSya5du2bMmPH666/v3r1bLpenpaXFx8d37tz51q1bX3/99eLFP/j7Izwcc+fiyBEwZoXREXOiGLUv9z245iaUzeuu3OR9pp5jtRjV6XT/+Mc/kpOTXV1dd+3aZXpCNQBnZ+eoqCiZTJaTk/Pnn39+9NFHgwfPFIvxxx9ITMTAgWjZEtOm4YcfoFYDwK+/Ijy85vWhQ1iyBG+9hTNnalpbswbbt1v625BHoBi1L/ceXF++fLl9+/bTp08vLy83Y0eNsxrl7ik6ceKERe8p0mq1EydO/P777z09PdPS0p5++ukH7SQovisAAAc2SURBVNmxY8e33347KWlQSQm2b8e0aWjZEkVF+OwzvPACfH0xZAiysqBWIyEBADQayOW4cQOmOf/SUpSVWe6rkDqhGLUvXLpxD33jpKenV1ZWbtq0qXfv3ma8pnLgwIELFizgqj+9Xq9Wq8Visbu7u7nar5/73lNUWFgYERGxdOnSjIwMo9HYwC40Gs2oUaN27Njh7e39888/czeGPpKbG8aOxaZNKCxEXh5Wr0ZUFBjDr79CIsHYsTh1CqdO3dn/+nXk5yM/H5Zfa4XUAc+r7xPrunDhwrBhw0QiUXx8vE6n4zZmZWWZHoYcGxvbwAeC3ou7xMff39+8zdbP22+/DWDRokWmLRs3bjT9dfD19Y2Ojk5OTi6t1wPm1Wr1U089BSAgIODs2bMNHGppKUtNZampLD6enT7NIiPZnj3szTfZxIls7FgWG8tiY1lYGNu8uYH9kIaiGLU7cXFxXDXat2/fnJwcbuN9H4ZsLjk5OQA6depkxjbrbceOHQAGDRpk2qLRaLg5H+4JphyRSBQWFpaQkMCVqHVpWaFQREREAGjVqtXFixfNNWAuRhljb73FJk2qidFjx2p+mpBAMco/ilF7dPjw4Xbt2gFwdnaWyWR6vZ7bfvz48U6dOgEQi8Xx8fFardYs3X344YcAOnToYOmn5tWFXC4XCoUODg6HDh26dzx5eXmrV6+Oioribr7iBAQETJkyJSUlRaVSPajZmzdv9ujRA0CbNm1yc3PNOGBTjKpUrEWL+8fod9+xtWuZ+Z6KTR4PxaidUqlUsbGxXFnav3//CxcucNu5hyFziyuHhoZmZmbWuwuj0Ziamtq3b1/cvrN+wIABZizT6m3BggVBQUEAfHx8oqOjk5KSrl+/ftc+KpXq+++/j4mJad68uSlPnZychg4devXq1bt2vn79erdu3QB07NixsLDQvKPNybnzbNFffmE7d7LNm9nlyzVbfvqJ7dvHjh5lu3ax//3PvD2TuqIYtWt79+5t2bIlABcXF5lMZqrOfv/99/bt2wNwcHBISEgwlat1pNfrv/3229DQUC59mjVrFhMTExAQAMDNzW3Dhg11PEy2EIPB8MYbbwQHB9c+hI+MjFyxYkVmZua9Y8vOzpbJZFFRUQ4ODlKp9K4ivaCggPu96tKlS1FRkRW/x9989hn79Ve+Ord3FKP2TqFQxMbGcmkSFRVVUFDAba+oqIiPj+eeutyvX7/z58/XpTWdTpecnMydGQAQFBS0evVqjUZzV0dDhw69cuWKBb9V3eTl5SUlJY0cOdLJyckUqf7+/twhvEKhuGv/kpKSgwcP1t6Sn5/PxXHv3r1v3bplxbH/zd697L//5atzQjFKGGOM7d69mzt6dXd3T0pKMm3ft28fV65KJJLdu3c/pAWtVpucnMzVZdwpwtWrV1dWVt6129atW/38/O7tiF8VFRVpaWlxcXGtWrW6q0SVyWQPmmU6f/58ixYtAERGRiqVSusPm3PmDHvmGRYfz376ia8h2DuKUVLj5s2bzz//PJcgw4YNM50B5M6i+vr63rhx474frKqqSkpK4tIWQLt27ZKSkqqrqx/U0Y0bN8aMGcPtPGrUqOsPaJYv951latOmTWxsbEpKSllZGbdbdnY29w/PoEGDTBuJfaIYJX+TkpLC3Wvk6elZu1q8b4aq1erVq1ebJmFCQ0OTk5PreCI1JSXF29vbKzDw+dOnt/F3OPwQpaWlW7Zseemll/z9/U156uLiMmzYsHfffZe7QWv48OHcKQtizyhGyd2uX78+evRoLjXGjx9/31N+KpVKJpOZ7vXs1atXSkrK404cFRYWvnf4cFhGRlhGxty8POWDC1jemWaZuHXthEKho6Pj888/b65rwohNEzBaT4bcz5dffvnGG2+o1Wp/f/+NGzeOGzeO237r1q3169d/8skn3DPfIyMj4+PjR40aVe+OfpTLEwsLNQaDt1g8r3Xrpzw9zfMFLKO4uHjv3r1//fXXyJEjw8LCaLVQAoBilDxQQUFBTEzMr7/+CiA6OnrZsmVffPHF2rVruXU9IiMjlyxZMmTIkIZ3dF2nW3L5coZaDSDKy2t+UJA7xROxHRSj5GGMRuO6devmzZun0WicnZ2rqqoEAsHo0aMXLlwYHh5uxo4YsL2k5OPCwkqj0dfBYUHr1p0lkitaLffT1k5OPg4OZuyOEDOiGCWPdvHixVmzZnXu3Pn69evz5883XVdvdgVVVYsvX86qqBAAY/z8irXaUDc3AAM9PDpJJBbqlJAGohgljYsR+K64eJdcPtLHB4y9GBDA94gIeQSKUdIYGRjbVlLyi0LBFaGvBwY6C2ltXNJI0Yl80hiJBAIAXSWS4d7eABxrrTNNSGNDMUoaLz8Hhw50SpQ0enSgRAghDULnRkkjpdLrGeBJF5CSRo9ilBBCGoQO6gkhpEEoRgkhpEEoRgkhpEEoRgkhpEEoRgkhpEH+H323hE1ui5UoAAADDnpUWHRyZGtpdFBLTCByZGtpdCAyMDIwLjA5LjEAAHicnZVLaNRAGMcnk91ks5vss/tud2OxpfVRs90+0XZjC3Wx0FoqrfUgAVEjpQfFSqUIFR8tWAqCClV6EhGEgqj4QOwG8eDjIkXoQS148OYLK1JQ0OSb9OAtnYGZ/DPM7z8z33yTfFuYX0ZmEc3KIFKyZq006wTDddSYT9a11WU+5M5czhpSZzXbrEZWWLPtK5L+nfXQlycm3wuNTCvXoVs8y6wZ5MEAr8Pg/wU0AM9S843Au5zzWLMCw9q8QgLgXieP8RoPI+o4ap7Ej6fdv9ICvIeabwVeoI5/E/Be+gRqBgMfvQGJgEi9AxIBiZbPkwzwU28gT1IgQG9A7kCQ3oCcQYg6BOQIwtQLaFDAIEJvQK5xmWMDAcumtPGuHJk/SonnSQrFHOM8huVj26BHIQcQd25ADsD+ivXkSA4maPl6sv/kejfA4DUDEv8U7QLy5DeQpubJZ6jcMe/B1v/wr30AvQq5QhXUPJk/45gP4i1WArntK9SvkABkHRv4kEdDIR2juMxgHTNxDbMalmRW0DGb0Fxu5OYQl0G8R8d8RONjsqcMCV5NiGten459oiYmdCwmZcmvYymo+VNaIKXjQFoLpnUcCmuhKApHdBzLoEy5i6nIoDKXm8GsEOf4SDiEPJzXJyZYgfOnAumgFGeQXbIT6YulqeY3JeulKPCFD79RwdK+90idHGkEPfJwkzpUvRHGtF3rNa6PXlIt/WV6wLi9uRP0ythVo7gnCRodGjZWqx7BeB5FjSPLRdD7V18VorEl0NLX1cKMUTQsvWF+nzp34iDo3M8ZtXZFBn2/uk4dQJj4i5PqdNINmj1wTpVvXgE98OdXITbdD/ojmi31vdsF7NFPlca9B8dA3xk8bkwtbgc9KPmN19km2Ne90R1t46XT0H9jeM7oepKAtT17fKF9ijkF+vnJs2r3+CTo9sBTteUW8SnenVMnFoZg3rcvatTzicugvVV7jdqx3eAfWnxpLHFnQHf/mDU+dxwGHfsHKpgyovtvGHoAAAIselRYdE1PTCByZGtpdCAyMDIwLjA5LjEAAHicnVZLjtswDN37FLqABZKiKHFZTPoBik6BFugduuqmc/+hPpEdoAViBkbCJ5ov/Nvy9vYnfthC+/y4ff39N6wP3bYtJAyJQ4B/XqoafhEANPsdI1SpQxKS0jggmhbCS/gfxfnahkWmkqcEqfpYKAI2v5ttger0haJIaSw7RGEkF8ueIvGIg2PmLF6WlKlHlCKwZh8LWzYojdiSZidLilIqjEpbaL7s7uYBVRzZLZV9eQkYc81ldl0F9rIocx2xYRJn11mNaq+vseTM4GPhyFLSyFBGdk9AIcQ5CwmT1xcimP0CRZ1zxC2neUhSxF8jUpl5huxjsS5BzWlWmsiX3VYZvrOU4uyXZltFBp8mds8Roc7pKYjnvHy6sneBBYZXKg9d9zyL7RdFnRszq5xn+vWKLyRpbgYtVHws1nVQadQcbEn4WHJUGFuq1YjQ64tS35jWuzw38HUWex6lvhnaHE2+yyztSbK2SlHQE8v351nEZlB0zCXAgy8XWDhWK9KwrfrwVPv5LIuVRPv3AGh0dAftiTk1dpaWhs4aOz4DPAAHhGXDgfLSmCQLmFQWKO2d6Q5q943ugOCkaV0wgQZaNvaPeAaHo3bc3kEGm0m4CExqvtECyzcLBg+NgeWoHdMBpANaoC5N6WBqasCVawNEC2gPbtxmkR05MImGDRqAQ/MthJcvn7tNu2G3Q1Pbb9N8fL1t73MopP0VNIAaAAABfXpUWHRTTUlMRVMgcmRraXQgMjAyMC4wOS4xAAB4nCWSvWrtMBCEXyWlDbLY/12RJnAgZW5xy5DK/XmCPHxmdTAIe9A3Oxr58Xh8///4+Dm+/10/52v9uvk+Ps/7uJ5yY731fuLREy8Q7uPrfOKjt9z89ntcOsU017Dp5sHjHYq6qA+dZMsNis0kkRgydbnLVoqpdNCstczXC2PLgJSLagWkmEpRa/AkKnpxi5eucdH0FUG1wcgiGxdP04oGMUiKtbdlWZhtTXj59mc2UUjwLbBNhkQgBU0JZY0mV0pUSy5p5QCdtAygTGK1Tp9USVtJYWackJQlx7tNEVJtIVfbILkUMVoxdOEtYI4ViosM4/YIxcgWJBfCMJDlBUTJX3Mj0rzDgRDuLV6e+wBFiN2MdYtoBfaJOaDLe49Od21fmxapPFCJsxXK8YnKeStLhXZc3A9idkdemNltoT+1bS2CGaiGLIhpmy8chnfP+BGa1JnZ7fYNZd/LdreUcf7+ATYPg2M70RQJAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f1a613444e0>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f0bde42fdf0>"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10935,17 +11196,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3de1xU1doH8N/MMIDDMFwU8YKIiKCCF8I0JVOTNBLMULLjpYtvgaeOaGYOeQNTc5IyNE3JNHk7+Sk6+RZ2U0wzzAzBBBQEQbxwEQQGhjvMzHr/2EgcvKQwM5uZeb6f/mD27NnrGcyfa6+199oCxhgIIYR0lpDvAgghxLhRjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBJCSJdQjBKiS2q1WqlU1tTU8F0IMRwLvgsgpLs4ehRz5+LiRTg54ckn8dNP+L//Q2oqNBrU1ECtRm0tWlpQX4+mJjQ0AJheVVXU0NDQ1NRUX1/f0tJSW1vLHcrPzy88PPyVV17h9QsRA6EYJeQvM2di/Xrs2NH68osvkJBw15179rxWUXGxw0aRSCSTyXJycsLCwmxsbObNm6e3Ykl3QTFKWuXm5lpbW/fr18/Cwnz/r/D2RlERMjJaX4aEYORIWFhAKoVYDBsbWFqiRw9YW8PaGhJJgqWlQCKRiMViqVRqYWFha2vLffDTTz9dtGjR8uXLAwMDHRwcePs+xCAEdE894fj4+Fy4cCEzM9PHx4fvWvhx9CjOncP//A/CwlBTg59+6vyhGGMBAQHHjh1bvHjxrl27dFcj6Y5oiom0qqysBODo6Mh3Ibz57TccOQILC0yZgoKCLh1KIBDs2rXLysrq448/PnXqlI4KJN0UxShpZeYxqlbjwAEkJeHLL/Hqq8jJ6eRxDh48uGXLFgCenp4rVqzQarWLFy9uaWnRZa2km6GTegIAtbW1tra2NjY2bXPN5mb3bvzzn/D0xPnzEIs7eZDc3Nzhw4cLBIK0tLSRI0c2NTWNGjUqJycnJiZmxYoVOq2XdCPUGyWA2XdFGxqwaRMAbNrU+QwF4Onp+a9//UutVr/yyitardbKymr79u0AoqKiCro4TEC6MYpRAgAVFRUAevbsyXch/PjgAxQWYswYzJ4NAF25dn7Dhg0uLi4pKSkff/wxgGnTpv3jH/9Qq4Xvv1+io2JJt0MxSoBbvVHzjFGlEu+/DwAKBQQCNDZi5EjMnw+VqjNHs7W13bZtGwC5XF5cXAxg69YPhg0r27lzwsGDuiybdB8UowS41Rs1z5P6d95BZSWmTcPUqQCwcyeuXEFmJqTSTh4wJCQkODhYpVKtXq0A0KePc3h4DwD/+heqq3VWNuk+KEYJYMa90aIifPQRBAK88w4AVFdj82YAePddCLvwl+PDDz98/PF9iYnbjhwBgPBwTJiAkhJER+ugZtLdUIwSwIx7ozt35jc24tln4ecHADExqKjAxIkIDOzSYQcOHPjkky9VVgpeew0NDRAKsXs3xGJ8+CHOntVJ4aQboRglgLnO1GdnZ2/Z4jV06LyNG9UAysqwfTsAKBQ6OPjrr2P0aOTltfZzR4zA0qXQaBAeDo1GB8cn3QfFKAHMdaZ+1apVGo1m0iR7Dw8LAFu3KmtqMGsWJkzQwcEtLBAXB6EQW7YgKwsA1q/HoEFITQXdHWpiKEYJYJa90ZSUlG+//dbGxmbt2rUA8vLyPvig7/jxMZs2aXXVxNixCAtDczMWLwZjkEiwcycArF6NoiJdNUL4RzFKALPsjUZGRjLGXn/99b59+wJYs2ZNc3PT8OE5w4fr8i/F5s3o0wcFBbh+HQACA/HMM6ivx7FjOmyE8IxuBiUAMGzYsIsXL2ZnZw8dOpTvWgzhhx9+mDFjRq9evfLy8uzs7NLT0x966CFLS8vc3NwBAwbotq3UVHh54dYSeigqQlkZfH112wjhE/VGCWBmM/VarXbNmjUAVq1aZWdnB+DNN9/UarVLlizReYYCGDPmrwwF0L8/KirQsydu3gSAJ5/UeYPE0ChGCRhjSqVSIBCYyQLDBw4c+PPPP/v377948WIAJ06cSEpKsre3l8vlBquBW2afmAaKUQKVSqVWq2Uymbgry3IYiebm5ujoaACbNm3q0aMHgK+//hrAypUrDTk07O0NsfivZfaJUaMYJeZ1Ri8Wi2fMmCGTyYKDg7kt27dvP3z48NKlSw1cybp12LDBwG0SvaAYJeY1Tc8YS01NValU69udVE+bNk0ikRimAK0WaWkA4OCgg2X2SXdAMUrM66JRoVAYFxcnFot37Njxxx9/GL6AL79EZCTOnAHQpWX2SfdBMWruGGNJSUkwm94oAB8fn2XLlmm12tdee01j2BszW1qwdi0ATJ9uyGaJflGMmi+tVnvo0KGxY8e+//77Y8eOXb58Od8VGU50dPSgQYPS0tJ2cvcVGUpcHPLz4eWF5583ZLNEvyhGzZFarf7ss898fHxmzpyZmprav3//+fPn+3FrHJkHiUTCBeiaNWsKCwsN02htbeujShQKWFgYpk1iEIyYk+bm5vj4eE9PT+5Pf+DAgbGxsQ0NDXzXxY+QkBAAs2fPNkxz69czgI0dy7RawzRIDIRuBjUXTU1N8fHxGzduvH79OgB3d3e5XP7SSy+Zw7Wid1NSUjJs2LDq6urExMS265/0pLwcgwdDpcKxY5gyRa9NEYPjO8eJ3tXW1sbGxvbr14/7E/fx8YmPj1er1XzX1S1wz01ydXWtqanRa0NLlzKAzZih10YIPyhGTZlKpYqNjXV2duYCdNSoUfHx8RqNhu+6uhGNRjNu3DgAK1eu1F8rBQUaKysmFLJz5/TXCOENndSbpvLy8h07dmzfvl2pVALw9/eXy+VBQUECgYDv0rqdtLS0cePGCQSCM2fOjB49Wh9NvPjiory8R0aNmrdzZ2efk0e6M75znOhYaWlpVFSUTCbj/nz9/f0TExP5Lqq7i4iIADB27Fh9dNUzMjKEQqGlpWV+fr7OD066A4pR03H16tWIiAhuuQ0AAQEBv//+O99FGQeVSuXi4gIgLi5O5wefMWMGgKVLl+r8yKSboJN6E6HVaj09PfPz84VCYUhIyOrVq/V0fmqqvv766zlz5tjZ2WVnZ3Pr4XPUanVVVZVKpdJqtdXV1YyxqqoqANxoSXV1tVarValUGo2mpqZGrVZPnDiRy03OyZMnJ06cKJVK8/Ly2gapianhO8eJbsybN08qlU6ZMiUrK4vvWowVd83T/Pnz229M49YRuW8rVqxo/3F/f38A69evN+xXIQZFvVETERAQ8PPPPyclJQUEBPBdi7G6du2at7d3bW1t+19jTk6Ov7+/nZ2dQCCwt7cHwC1ubW9vLxAIZDKZSCSytbW1sLCQSqVisXjcuHGTJ0/mPvvtt9/OmjXLyckpPz/ftv0K+MS00C1pJsKsFrvTE1dX17Vr18rl8n/+85+ZmZnW1tYAvLy8ysvLO3E0jUazevVqAOvWraMMNW10T72JMKvF7vRn+fLlo0ePzsvL27x5cyc+Xl1drVQqr169evny5U2bNl24cMHNze2VV17ReZ2kW6GTehMhlUrr6upqamqkUroysUtSUlLGjx8vEokWL14skUhaWlpqa2vVanVNTY1Go7nbXFNVVdXtf5VsbGx27969YMECHr4GMSCKUVPQ3NxsZWVlaWnZ1NTEdy2mYOzYscXFxUVFRQ/6QW6olBsktbGx+frrrwcPHiwU0jmfiaOxUVNAA6M6VFJSkpWVVVdX9+KLLw4dOtTCwsLW1lYkEslkMqFQeLe5Jjs7O4pLs0UxagrM6pl0+vb222/X1dWFhIR8+umnfNdCjAP9+2kKuPkl6o123aVLl/bu3SsSiTbQQzvJfaPeqCkQi2vmzx/Rr98gvgsxemvWrGlpaXn55ZeHDx/Ody3EaNAUkykoL9979erLvXr9z8CBn/BdixFLS0t7+OGHrayscnNzBwwYwHc5xGjQSb0pUKsrAIhENDbaJZGRkYyxiIgIylDyQChGTYFGUwnAwoLGRjvvl19+OXr0qL29vVwu57sWYmQoRk0B1xu1sKDeaCcxxiIjIwFERkbSBQ/kQVGMmoJbMUq90U5KSEj4448/+vXrt2TJEr5rIcaHYtQUcCf1NDbaOWq1Ojo6GkB0dLREIuG7HGJ8KEZNAfVGu2LPnj0XL1709PR86aWX+K6FGCWKUVNAMdppDQ0NmzZtAvDOO+9YWNBl1KQzKEZNgVpNJ/WdtHXr1qKioocffjgkJITvWoixosvvTYC2tHSrRlPVr99GvisxMkqlcvDgwUql8ujRo1OnTuW7HGKs6CyGJ4xBLodKhZYWDBmCyEgcOgS1GmVl+PxzODqiZ084OsLREb16oWfPJr/e2t4yC4ueIpGjUNij7TCNjReLilaJxf0Ya+Dx2xipjRs3KpXK6dOnU4aSrqDeKE8OHEBhIVauBICICMyZg8ceA4AlS7Bjx+27X/nZv8LuN+5nobAHl6cWFo49evja2Pg5Os7n3qqrO8NY4613ewoEYsN8G2NUVFQ0ZMiQxsbG1NTUhx56iO9yiBGj3ihP0tMRFNT68/jxSE9vjdE338Szz6KiApWVqKho/a+yUmwr7dFDpVZXajQVWm1Dc3MhUAigT5/I2trfrl59xcLCsV+/jUVFkTU1x9oaEYlsuTx1jx9mdVXzVw+X+6FnT/j5QWymUbtmzZqGhoZ//OMflKGki6g3ypN//xulpXjjDQB4/XU8/TRuPU7yb2m19Wp1pUZTqVZXSCR+IpEMQGHhSpksoLr6x/r6VC5t1epKxlq4j4wI72eZVnyHY1VVYdOmO4wtPPPMvWtIUak+Ki72lEjsRaJX+/e/32/dbVy8eHHEiBECgSArK8vDw4Pvcohxo94oT+bNw8qVeO01tLTAze3+MxSAUCixtJQALgCqqr5RqQ4LBJYtLSU2NmNlsmnt99RoVFzaimMqcaO8tYdbWdn6Q1UVvvsOvXphyxYAiIjAr78iOPg+y5hsb/9inz73Xzbv6urq8m/Zu3evWq1+9dVXKUNJ11GM8kQoxHvvdf0w9vazhEJJbe1JB4c5IpF9h3dFIplIJLO0dMOUu3xeLr/z2MJ9+KWqqri52cfGZmb3Wy5aqVRevs2VK1e0Wi23g1AotLW1nT17Nr91EtNAMWr0VKojpaXvi0R2UunEB/7wiBFIScHEiQCQkoKnn77/j3aH3ihjrLCwMP823DM7O7Cysho0aNDgwYMHDx6ckZHxyy+/7Nmz5/HHHzd82cTEUIwavS4t79SFsQUenT59+p133snLyysoKGhsbLx9B5lMNvi/eXh4uLi4tD11rqSkxN3d/auvvoqOjvby8jJs+cTUUIwavVtrNnfqzLqzYwvpdXW59fVZdXXDbWw6024XJCcnb9q06fDhw9xLBwcH99sMGjRIIBDc4yB9+/Z98cUXd+/erVAo6NF1pIsoRo0eL2s2n62pOVNTE9q7tyEb5Zw4ceLw4cMzZ858++23Bw8eLJVK771/aWlpfn5+Xl4ed77/9ttvu7u7A3jrrbf27dv32WefrV69miaaSFdQjBo9XtZsrtZoANiLRIZslJOZmQkgJCRk1KhRHd5SKpUXLlzIyspqm1a6dOmSSqVqv8/cuXO5GHV1dZ03b97+/fvfe++93bt3G6x+YnooRo0eL8s7VavVAGR8LInExejIkSO5l8ePH4+JicnPz79y5Upzc/Pt+zs6OrYfJPX19W17a/Xq1Z999tm+fftWrVrl6upqmPqJ6aEYNXZMo1ECApHIwZCtqtRqAHYGj9GmpqZLly5ZWFgMGzaM21JTU/Pjjz9yP98+Turt7d23b9+7Hc3DwyM0NPSLL77YunVrbGysIb4AMUV0F5Nxa2hoOnNmobV1/dix3xms0WbGJpw9KxYIfjf4bZRpaWljxozx9vY+f/48t+XmzZunTp3iepo9evS498dvl5WVNWLECEtLy8uXL98jcAm5B1pv1LiVlFhNmpTw3HOGy1DcOqM3fFcUQEZGBoARI0a0bXFycnr66ad9fHw6kaEAhg8fPnPmzMbGxm3btumsSmJmKEaNW2UlABj4NiK+zuhxa2C0fYx23bp16wQCwY4dO8rLy3V4WGI+KEaNW0UFABj4kcCtvVH+punb5pd0wtfXd/r06XV1dTvutEQhIX+LYtS48dMbbW4GT9P0paVi6Lo3CmDdunUAYmNj73gXKSH3RjFq3HjpjeZ/882fjzzSsHOnQVsFSkuRmfmDq6tG5xcnjR8/fvLkydXV1bt27dLtkYk5oBg1brz0RsvLy7VqtdTg6z2npwOAm5vw3jd6ds6aNWsAvP/++7W1tTo/ODFtFKPGjZfeaGVlJQBHA7cKZGQAgE7HRf8ydepUf3//ioqKPXv26KUBYrooRo2bpSWcnODkZNBGuRjtafBlRjMzAUDX46J/eeuttwBs2bKloYGeD0geAMWocYuJQVkZ5s0zaKMVFRXgrzeqvxidMWPGmDFjbty4sX//fn21QUwRxahxOHoUCkXrzwEBrVt69sTNmwDw5JMGLYaX3qhajexsCATw9tbxkdvfyBcZGQlAoVDc8fZ8Qu6IYtSIzZyJ9et5aJeX3mhODpqa4O4OmUyXhy0oKHjkkUcuXLjAvQwJCfHx8bl27dratWspScl9ohg1Gt98g8WLsXgxSktbt3h7QyxuPdU1JF56o/qYX8rKyvL3909JSYmOjm7b6OLiYm9vv2XLFgcHhyeeeGLbtm3Xr1/XZavE5FCMGo1Zs7B7N3bvhrPzXxvXrcOGDa0/r12L//zHEJXwMlPPzS/pMEbPnTs3efLkkpKSSZMm7du3D4BWqw0PD//pp5/q6uo8PDzq6+uPHj26bNkyV1dXX1/fVatWnTx5UqPR6KwCYiooRo2bgwOmTEFBAVJSsGkTQkMxb17rxaT6kJ6evmDBArFYLJVKt23b1vagTQN47DG89hqm3O0Rpw8oLS0tICDg5s2bgYGBP/74o62trUajWbRo0Z49eyQSyXfffXfp0qVr167FxcXNmjVLKpWeO3du8+bNEydO7N2797Jlhf/7v62j0oQAACMmQatlcXFMKmUAc3Zm33yj4+OfPHkyMDCQ+3/G0tKS+2HKlCkFBQU6bkn/kpOTZTIZgODg4MbGRsZYU1PTnDlzANjY2Pz8888d9m9paUlOTpbL5X5+flZWMhsbLcCEQubnx+RylpzMNBo+vgbpNihGTUpBAZsyhQEMYKGhrLJSB8dMTk4OuvUse6lUGhERUVRU9P333/fr1w+ARCKJjY3VarU6aOkukpKYoyMrK2OMsenTu3q048ePc49veu6555qbmxljjY2Ns2bNAmBvb3/q1Kl7fzw//8b27ezJJ5m1devvGWC9e7MXXmBffqmbXzgxOhSjpobrltrYMIC5urKkpM4fKikpafz48VyA2trayuXyioqKtneVSuWCBQu4d6dNm3b9+nUdVH/nMtiLL7LXXmOsyzH6/fffW1tbA1iwYIFarWaM1dXVPfHEEwAcHR1TUlLu/1D19SwpicnlbOjQv/J0wQJdJj4xFhSjpikri40dywAmELDo6GO1tbX3/1mtVpuYmPjwww9zEdmrV6+oqCilUnnHnRMSEnr16gXAzs4uLi5OR+UzxlhlJYuOZps3s6QkFhPDli1j6els+nTW3MzeeosVFT3wARMTE62srAAsXrxYo9EwxmpqaqZMmQLA2dk5IyOj06VeuMBiYtjjj7MPP9RZ4hMjQjFqslpamELBxo0rFwiEgwYNOn78+N9+RKPRJCYmtj30rXfv3gqFoq6urm2HlJSUAwcOdPjUjRs3uJNiAE899VRRJxLuv5WWsshIZmvLACaTsW+/ZTExrLKSzZnDpk9nH37IACaRMLmc3SXb7+DAgQMWFhYA3nzzTW6LUql85JFHALi6uubm5naxZk6HxCdmgmLUxJ07l849iFgoFK5YsaKhoeGOuzU3N8fHx3t5eXFpOHDgwNjY2Pr6+rYdTp48GRQUJBAI7Ozs7tgzTUhIcHBwAODk5PSf//ync9XeuMHkciaRtJ4j+/uzo0dbs4kxtnMn8/RkFy+y0FAmEDCAOToyhYK1K/POPv74Y6FQCEAul3NbSktLuV+Lm5tbfn5+56q9HVdqW+ITM0ExavpaWloUCoVYLAYwbNiwDiOATU1N8fHxgwcP5gJ00KBBsbGx3Pw158iRI4899hj3rkwmi4yMrKqqumNDxcXFM2bM4PYMDQ0tLy+//yKvXGEREaxHj9aBiKAgdvr0vfZPSWGPP96atv37s7g41tJy5z137drFLaz37rvvcltKSkp8fHwAeHl5FRYW3n+Rf6st8T/4gLm4sLv8noipoRg1F+fOneP6XxYWFnK5vKmpqba2NjY2tn///lzweXt7x8fHt7RLo6SkJO60lwvQDlNMd6TVauPi4ripcGdn52/u48KrnJycJUs2W1oy7iqiuXNZevr9fqmffmK+vq1hOmwYS0xU3X7NwOnTp2UyWWxsLPfy6tWrHh4eAIYPH15cXHy/LT2ggAAGsIMH9XR40r1QjJqRhoaGN954gzu9HThwYNttSH5+fgcPHmwLIG6EdMyYMdy7Tk5O95hiuqPLly9Pnjy5rVtaeZfrgDIzMxcuXMgNWY4fXxQayrKzH/hLabUsIYENGcIA5uv7xtixY48dO9Zhn9LS0rbCBg0axH3lB+osP6ioKAawpUv11wLpRihGzc6pU6fc3Nz69OkDYMKECYmJie0DNCEhYdiwYVwCOjs7d5hiun9ct1QikXBzOEePHm3/7pkzZ2bNmsWda1tZWYWHhxcUXOnKl2puZp98Uu586z7ZwMDAc+fOddgnOzub63o/+uij1dXVXWnubx0/zgA2erReGyHdBcWoOdq7dy93sWfbFm6KydPTs/0U093mo+5fVlYWd+GUQCAICwurqalpm6riAjQsLEyHF5zW1tYqFAp7e3uuxdDQ0EuXLnFv/fnnn05OTgAmTZqkUql01WJ7KhX74Qf222+MMdbQwKytmVDI/m4UhJgCilFztG3bNgBLlixp28Kts8nNuuzfv7/lbvM1D66lpWXDhg3c/aPcVH7bxfxt59q6VVFRIZfLucvsxWJxWFjY4cOHufWoAgMD6/92Xr+zPvmEAWz27NaXEycygCUm6qk10o1QjJqjqKgoAFFRUW1brl696ufn98UXX2j0c394Zmamm5ubq6urRCK5n6mqrrty5coLL7zADQRzIR4SEtLU1KS/Fi9dYgBzcmLcGMmaNQxgb7yhvwZJd0ErPJkjbt3l9guGurq6pqamzp07l8sdnfPx8XnmmWeuXbsWGRmpUCgMsMjewIED9+/fn56ePnHiRDs7Ozc3ty+//LJtURV98PBA//64eRPZ2QAwaRIAnDihvwZJd0Exao54WTC0qqoKQNv1VYbh4+Nz4MCBmzdvKpVKfTyWuQPu+louOidMgKUl/vwT1dX6bpbwjGLUHN3eG9WH/Pz8BQsWxMTEcC/5ep6oi4uLu7t7dXV1Ovece31q3wOVSODnB40Gv/2m72YJzyhGzZFhEu3y5cuff/75kSNHuJd8PU8UwKRJkwCc0P8JNnex7IkT4J6SFxJyZsSIxSdPRum7XcIvilFzZJhE69Dn5as3CgPGqJcXgoKSevZclJOTA2DEiMrMzLhjxw7ru13CL4pRc2SYk/oOI7C890aTk5MN8NQTieSTCxc+/fXXEwD8/f3FYnFaWlpNTY2+2yU8ohg1O2q1WqVSiUQimW4fVXybDmGtVCrBU4y6ubkNHDiwsrLy/Pnz+m6rfc9XKpX6+vqq1erff/9d3+0SHlGMmh3u7ngHBwc9XdvUpn1vVKVSNTc329ra6vWSo3vgFqkywHk9F6PHjx9v/9IA7RIeUYyaHcOc0XdoiJdLrNozWJwNHz68d+/eJSUl+fn5hmyX8Ihi1OwYbKqnfXQaLLvvhouzX3/9lXGT6HojEAgeffRR3IrORx99VCQSnTlzpr6+Xq/tEh5RjJodg031dKveqIeHx4ABA27evJnN3WOkT5MmTbKzs+NuN7Czsxs1alRzc/Pp06f13S7hC8Wo2TFYx7B9t5f33igArpP4yy+/6LuhsLCwioqK5cuXcy+5pVe/+uorfbdL+EIxanYMdlLfvtvL40WjbQw2TGltbS0SidpelpaWOjs77969u0+fPs8///xXX31VTfeHmhaKUbNjmPNrrVZbVVUlEAi41T95vGi0DdcrNMDwaBvG2LJlyz7//POKiopevXqVlpZ+9tlnzz77rLOz87Rp0z744IPc3FzDVEL0imLU7Bgm0aqqqjQajb29PfeMEN7HRgF4eXn169fvxo0bhgkvxlhERMS2bdssLS0TEhLKysrOnj27cePGCRMmqNXqpKSk5cuXe3l5eXh4REWV/PQTGhsNUBTRC4pRs8PjLUz8ntTj1vCoAc7rNRrNokWLduzYIZFIDh069MwzzwgEAl9f39WrV//2229lZWUJCQlhYWF9+/YtKqp4772+gYFwdMQTT+Ddd5GTo+/qiI5RjJqd24cp09LSDhw4oNtW7nhDPb+9URhqeLSlpeW5557bv3+/jY3NoUOHpk2b1mEHR0fH0NDQuLi4wsLCX39NeeMN+PmhsRFHjyIyEkOHwtsbb76J48fR0qLXSomO8LpoNOHB6NGjAZw9e5Z72djY6O3tDWD27NllZWW6auWHH34AEBgYyL3kHtR86tQpXR2/c7ibQfv27dt+4/Xr13NycnTVRGNj46xZswDY29s/0PctKWH79rHQUGZn1/rIaIC98AJzdGTcH8v06YwxlpTENm9u/cjUqbqqmnQJ9UbNjqWlpUgkSk1N5V5aWVlFRUU5ODh8/fXXPj4+Bw8e1EkrgYGB1dXV+/fv5152k95oh1uMOLt27fLy8nJ3dw8PD//qq69qa2s7ffz6+vrg4OBvvvnGwcHh8OHD48ePv//P9umDl15CQgLKy3H8OFauhI8PxozBzJlYv77TFRGD4DvHiaElJydzf/QLFy5se/r8lStXpk6dym0PDQ3V+TPcubP7mzdv6vawnRASEgJg7969bVvWrVvXq1evtr8REsbnCnwAAAWcSURBVIkkKCjoo48+KigoeKAj19TUPP744wCcnZ0zMjJ0Um1SEouJYcuWsfT0v3qj48ax8HAWHs58fHTSCOkqilGzwz1BXiqVAujTp0/irWdXdtj+7bff6qpFjUYjEokEAoEOHzjaadxTUZ9//vn2GzUaTWpqqkKh8Pf3b79ii7u7e0RERFJS0t8+C0+pVHIDFwMGDMjNzdVVtVyMVlayOXPopL77ohg1U5cvX+YWPeK6pW2Pbr98+TI3D9Nhe6dlZGTMmzdPJpPZ2trGxcV1ufCu4h4lYmtrGxoaGh8fX1lZ2WEHbhp94cKF3BWvHBsbm6CgoLi4uOvXr99+zLKyMm7E2c3NLS8vT4fVcjHKGNu5k3l6tm7pEKM//MDefZctXarDZsmDoRg1XxqNJjY21srKCsDAgQN//vlnbjvXLZVIJB22P6g//vgjODiYe5CcWCzm8ig4OLikpER3X+KBaTSatlXsAFhYWEycOHHz5s3p6ekd9lSr1ampqVFRUX5+fm2PwwsODu6wW0lJyYgRIwB4eXndMWQN49VX+WqZUIyavQsXLowZMwaAQCAICwurra299/b7kZycHBQU1NaPi4iIKCwsTEhI4EZI7e3tee+W5ufnx8XFBQUFcf+KcHr37r1w4cKEhISqqqoO+1+9enXXrl3BwcH79u3rsH3IkCEAhg8fXlxcbMBv8F9iYlhKCl+NE4pRwlhLS4tCoeAWVHZ3dz9x4sS9t99DcnJy21SVVCqNiIhoHy4lJSUzZ87k3p0zZ053mHGqq6tLTEwMCwtzcXFp30X19/dXKBSpqan3+GxBQYG7uzuAhx56iMfvsm0bmz+fffAB02r5KsHcUYySVhkZGb6+vgCEQmFERERjYyO3/ezZs9xJ61NPPXWPjyclJY0bN46LIZlMJpfLbx925MTHx9va2nK9v4MHD+r+m3TW+fPnFQpFQEBA2xAEgEGDBoWFhSUkJNTU1LTfOTs7u3///gD8/f1v770Ss0IxSv7S3NwcFRXFrU7k7e195swZbntjY+PatWvvOPCn0WgSExP9/Py40HFycoqKivrbWCkoKOAWCgEQuXWrSq3W/ZfpgoqKirabNdvytEePHgEBAQqFIjs7+/z589xbkyZN6vosHDF2FKOko9OnTw8dOpQ7t5XL5Xe71kej0SQkJAwbNoxLGWdnZ4VCUVdXd5+tcBNZPfv0mZmWNi09/US37NBpNJrTp0+vW7duzJgxbbNM3HgFgMDAwPr6er5rJPwTMEMtGkaMSENDw/r162NiYrRa7ciRI+Pj47kLejjNzc1ffPHFxo0bL126BMDNzW3ZsmXh4eHW1tYP2lCBUrmhtDSjrk4APOPktMzFRaLnB+11Wnl5+fHjxw8dOvTdd9/NnTu3rq7uk08+4esJfaRboRgld3Xq1KkXXnghLy9PLBavWrVq7dq1arU6Pj5+w4YNhYWFANzd3eVy+aJFi7jV8DpHC3xZVvZhYWEzY/0sLde5uY2xtdXdl9A9tVrd1NRkY2PDdyGku6AYJfdSU1OzYsWKPXv2MMaGDBlSVVV18+ZNAKNGjVq1atWcOXN09ZTmyw0N0VeuZNXXC4BnevV6fcCAHt21W0pIBxSj5O8dOXLk5Zdftre3z8zMHD16NBeg7ccKdULD2L9LS3cXF7cw1t/KKtrNzVcq1W0ThOgDxSi5L1VVVfX19bm5uW0z7HqSXV8fdeXK5YYGjx49Xndx2VVc7CmR2ItEr/bvr9d2Cek0ilHS7TQzFldcPNXBoVatzqqvf7FPH74rIuReKEZJ95WiUn1UXOwpkfjY2Mzk+wEkhNxN5ydYCTGAyfb21Bsl3RxNhhJCSJfQST0hhHQJ9UYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRLKEYJIaRL/h/s60VWu6olBAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvomK+y5uIKJkWmJp4laiP/NaSYleLaybNm6Ja3fQFnJJx9stqW4ZZiqaaWSmGGoQKiCmSYgoKjIMw7DNMDPP74+DI+4IszDM9/3qxWvmcHieZ0w+fs95znkOjzEGQgghjcW39AAIIcS6UYwSQkiTUIwSQkiTUIwSQkiTUIwSQkiTUIwSctv58ygrq3t94QI0GouOhlgJilFCbps5E6+9Vvf6n/9EcbFFR0OshNDSAyCkedFq8cMPGDMGAGprUVyMigpotVCpoNOhvBx6PZRKAFCrc6uqjpWVlTHGuK9KpVKv15eXl+t0unnz5vXt29fFxcWyH4eYAcUoIXdYswYvvoinngKAAwcwZ84D9xw+vOTXX2c96LuZmZmDBg363//+Z4IxkuaFYpSQO/j7Izoaa9YAgFgMHx+IxRAI4OoKPh9ubuDx4O4OAN27u3btGuPm5sbn87mvrq6uAoFALBaXlZUtWLDg66+/njZt2nPPPWfZT0RMjUc3gxIAaWlpS5cujYiIWLx4saXHYklPPoldu+DmhqFDUVqKQ4fQpk0jm1q7dq1EIuncuXN2drajo6NRh0maF5piIgBw6dKlw4cP5+TkWHogzYJQiI8/xsWLTWrkX//6V79+/S5evPjee+8ZaVykmaIYJQBQWloKwMvLy9IDsaTDhzF5MlxdASA0FMeOwcenMe0cOHBAr9cLhUKZTMbn8+Pj48+dO2fcoZJmhWKUAIBcLgfg6elp6YFYjE6HuXPxxhvYu7duy+DBcHB47HZmzpw5evRomUwGIDQ09LXXXtNoNLNnz6azZy0YxSgBblWjthyjn3+Oc+fQoQMiI5vUDjehtHDhwqKiIgBr165t1arV0aNHv/jiC6OMkzRDFKMEuFWN2uxBfU0NVq4EgPfeg719k5qaOHHiuHHjysvL3377bQBubm7r1q0DsHnzcbncCEMlzRDFKAFsvhpdvx6FhejbF5MnA4Be36TWNmzY4OLisn379h9++AHAtGnTYmJO/vHHlnfeMcZYSfNDMUoA265Gy8oQHw8Aa9eCz4dOh9BQSCSorGxkg4GBgcuXLwcwb9686mo1gAULQoVCfP45Dh821qhJM0IxSgDbnqmXSlFaimHD8MwzAJCYiD/+wI4dsLNrfJvz5s0bMeJlb+/UNWscAHTujEWLwBj++U+o1UYaN2k26PJ7AgCenp4KhUIul9vacX1REbp0QXU10tIQFoaaGnTrhsuX8fXXmDq1SS2npyMsDEIhTp1Cz57QaNCvH86dw5o1sO1bHFogqkYJdDqdUqnk8/nu3E2OtmTLlhNCIXvhBYSFAcCGDbh8GX36YMqUprY8cCBiYqDRYPZsMAZ7e2zZAh4Pq1cjL6/pAyfNCFWjBHK53Nvb28vLq6SkxNJjMasLFy706tXLw6PzsWMZXbs6l5Whc2fI5ThwAM8+a4T2y8vRoweKivDZZ5gxAwBeeQWJiXjmGRw8aIT2STNB1Six3WvvFy9erNVqJ058smtXZwBbt/5dVobhw42ToQBcXfH++wAwfz5u3gSADz6Ajw9++gnffmucLkhzQDFKbHSaPj09/fvvv3dycnr33XcBXLt2bcWKoI4dJ65bV23EXqZOxbPPwsGh7kDeywtSKZydUV5uxE6IhVGMEhu9aHTRokWMsXnz5rVp0wbAihUrqqqq+vQRhIQ4Gbejzz7DuXN1514BzJiBtDT88gtKSwFAocDy5cbtkJgbxSixxWr04MGDhw4dcnd3X7BgAYC//vrrs88+EwgEq1atMnpfAQFwc7v9lseDmxtSUrBwIQBUV+PIEaP3ScyKYpTY3EWjjDFuWdXFixdzNfiSJUtqa2ujo6N79OhhnjGEhqKoCGlp5umNmBbFKLG5g/rt27dnZmYGBATMnTsXQEZGxnfffefo6MidJDWbjz7CvHnQas3ZJzEJeogIsbmZ+n379gGIi4sTiUQAqquru3XrNnbs2LZt25pzGF26YPRobN5szj6JSVCMEps7N+rj4wOgoqKCezt06NDs7GyNJZ5Jv2gRQkLg62v+nokx0UE9sbmD+lGjRgFYvnz5lStXuC1CoZCrTM2Dx0PnzgDg5IT330fXrmbrmZgExSixuWp01KhRkyZNUqlU8+bNM3/v1dUYMQIODqipAYDRoyGTmX8UxJgoRm2aWq3eunVrXl6el5eX7VSjADZs2ODu7v79998nJyebuev163HxIlJSmro+NGk+KEZtlEqlio+PDwwMnDVrllKp3LRpU4cOHSw9KPPx9/dfuXIlgDfeeMNwktQMysqwdi0ArFsHPv3ytRiM2BilUimVSg21Z79+/ZKSkvR6vaXHZW46nS4sLAzA/PnzzdbpO+8wgA0bZrYOiTnQCk82pKSkZOPGjR9//HFZWRmA8PBwiUQyduxYS4/LYrKysoKDgwH8/vvv/fv3N3V3d61tSloOS+c4MYcbN25IJBLDZHR4ePjPP/9s6UE1C9ws08CBA3U6nan7eu01BrCoKFP3Q8yNqtEWrqCg4MMPP/zPf/5TXV3N4/HGjBmzdOnSQYMGWXpczYVKperZs+eVK1c2b948e/Zs03V04QJ69QJjyM6Gue44JeZi6RwnppKXlxcbG+vg4ACAz+dHRkZmZGRYelDN0c6dOwG4urpevXrVdL08/zwD2KxZpuuBWAzFaAuUk5Mzffp0oVDIBWhUVFRubq6lB9WsjRs3DsDUqVNN1P7Jkyd79ZoxaJDclEFNLIZitEU5ffr09OnTBQIBAHt7++nTp1+4cMHSg7ICBQUFLi4uAH744QdTtP/000/j1gqnpOWhGG0hTpw4MXr0aO5EjZOTU2xsbGFhoaUHZU3Wrl0LoHPnzlVVVcZt+ccffwTg4eEhl8uN2zJpJmiKqSUoLi5euXLlpk2bXFxcoqOjJRJJQECApQdlZbRa7cCBA0+fPr106dK7Fm/ev3//lStXdDpdeXm5Xq9XKpWMMe6iMYVCAUCpVOr1+vLycp1Op1KpMjMznZ2duZ9ljIWEhGRmZq5bt27+/Pnm/1zEHCwc48QYEhMTAfTr14/qnaY4efIkn8+3t7c/e/Zs/e2Pe0lpSUmJ4We//vprAK1bt66srDT7ByJmQgvltQTc2iLDhw+3qfvijS40NHTmzJkymWz27NlHjhzh8Xjc9rFjxw4cOJDP57u5ufF4PHd3dwAeHh4A3Nzc+Hy+q6urQCAQi8VCodDFxYXbAUBtbe2yZcsArFy50pwrSBEzoxhtCWxtpTvTiY+P37t3b2pqamJi4iuvvMJtXLFiReNa27p168WLF7t16/bSSy8ZbYik+aEYbQlsbaU703Fzc1u3bt20adPmz58/ZswYboHn+zKcCdVqtRUVFbW1tZWVlRqNpqqqSq1W19TUlJWVLV++HIBUKuUuPiMtFf3fbQmoGjWiF198cdu2bSkpKSEhIZ07d37QhFJDmurfv/+AAQPGjx9v2hETS6MYbQmoGjWuSZMmpaWlXb58+fLlyw/ax3Am1M7OztnZ2d7eXiQSOTg4ODo6Ojk5OTg4iESisLCwGTNmmHPkxCIoRlsCW3tCsknpdLr169dXVlbOnTt34sSJ9SeU3N3deTweN6Fk6WGSZoRitCWwtUd7mtSXX3559uzZ9u3bf/DBB9yKBIQ8HC3A3RJQNWosGo2GWxV/1apVlKGkgagatXqM1f76q79W25W7K5w0xcaNG/Pz84OCgl588UVLj4VYDYpRq6fVyhn7y9HRz3C5OGkc7vlUAKRSKZ+elEQajP6uWD2tVg5AIKAj+qaKj48vLi4eOnToc889Z+mxEGtCMWr1dLpSAEIhzS81SXFx8fr16wFIpVJLj4VYGYpRq8dVo0IhVaNNsnz5cpVKNWHChCFDhlh6LMTKUIxaPa22FIBAQNVo4+Xn5//3v/8VCASrV6+29FiI9aEYtXo6HVWjTbVo0SKNRvPyyy/36tXL0mMh1odi1Opx1SidG220M2fO7Nixw9HRMS4uztJjIVaJLniyHK0W+/ahoAC9eiEiognNcDFK1WgjvfPOO3q9/vXXXw8MDLT0WIhVooeIWIhOh2efxRNPICQE+/ZBp4NEgv374eaGl19+rJZKSj5VqQ55e88Wi4eZaLAt2JEjR4YPH+7m5paXl0e3gZHGoWrUQvbuRbt2WL4cACIjMXgw1GrMmIHHvOq7puZcefnPWu3NiopfKUYfF2Ns4cKFACQSCWUoaTSKUQs5exbBwbffhoQgJwdDh8LLC56ed3z19KwYE6D3dhYIvIRCT6HQWyBwM/xcQUFMmzbrRKJgjeaBS7o9Wm0t8vPh7w9X1yZ8JOuzc+fOEydOtGrVKjY21tJjIVaMYtRCxGJUVNx+W1EBxqBQQKG4d9+rg/tUKLIMb3k8ARep3t4xPJ6guvqss3Oog0MntfpiVdUfQqH3rcD15PMbcJf9Dz8gLg5hYfjzT/TqhQ8/xN9/A0CHDmjRa7brdDruQUlxcXGGB3kS0gh0btRCcnLw2ms4ehT29lAoMHgwTpyAXg+5HKWldV9vvbgyV1styNfpSrXaEq22VKdTcm0EBKzy9JxSVLSsqiqzVatlOp3q8uV/1u+Ex3MQCj0dBO27zbG7o8jl/vP0RI8eGDoUJ07AwwMAoqLwj39AowGAyEg4Od137Evy86+p1Y58PoAVHTr42NmZ8k/KVLZu3Tpr1qwuXbqcPXvWzjo/AmkmWnK50az17o0ZM/Dkk+jYEXl5+OgjcI+TvN+aoW3ufMuYVqcr1WrlAoGnnZ1fhw7faLU3c3P7tmv3iYdHlFYr576r1Zbq9ZW1tdcEOicc/fv+w/j2W/ToUZehAMaPx/HjeNTdkBq9fmG7dl0fELJWobq6mnsY/Zo1ayhDSRNRjFrOrFmIiYFCcd/ofAgeTygU+gqFvgCqqjKcnPozpuHx7Fxdn3Nzm1B/T8bUWq1cX6nAryW3y9uSeq9dXFB/IXc7u7pS9FFyKioUtbUigSDIeg6HlUrlxYsX8/Ly8vLykpOTr1y5MmDAgEmTJll6XMTqUYxaFI/3uBl6F6Xyh6KiZYCgffvPeDz7e5p3sLMLgHsAHjSHX1aGt95CbS24iuzYMYSFNaTfv2tqlDqdl1DYPGNUoVD8fT/19/Hy8ho0aBCtLkiajs6NWrfKyvQrV+aLxU8GBKxqZBMJCUhJQVQUzp7FmTPYv/+RM0sL8vJmBgQ0h4N6rVZbWFiYl5dnKDM5lZWV9+4sEok63VJdXf3JJ5/4+/v//fffTs3ggxCrRtWoddNoCioqjtrZPfBx6o/25pt49lmcOoUxYyCVwhoe1paRkfHuu+/m5eVdunSptrb23h28vLw63alz586tWrWqv096enp6evpnn302d+5ccw2ctExUjVq3mzdlly/P9vaOaddOZrZOfykr6+vi4mWhy6FOnDixbNmylJQU7q2Hh0fHenr27Nm7d2/ucZ4Pt2vXrueff75t27YXL160t7/7fAghDUfVqHWzyJrNA1xcRp4509bR8XtLrIf022+/paSkPPfcc2vXru3UqZOjo+PD91coFPWP91944QVucfsJEyYEBQVlZ2d/+eWXr776qlnGTlomilHrZpF1SZRaLQMsNTWTnZ0NYNy4cfcuateQmSV/f38uRnk83qJFi1588cV///vfL7/8srBF32tATIr+6li3Ww9iMms1qtRqAbhZ6CwqF6NBQUHc24yMjDVr1nCVZlVV1b37Ozs71z9DOnjwYMO3Jk+evGLFivPnz3/77bfTpk0zz/hJy0Mxat1uHdSbtxrV6QC4WaJ802q1ubm5PB6vd+/e3Ba1Wr17927u9V3nSTnt27d/0GM+BQKBRCKJjo5es2bN1KlT6WmgpHEoRq1baWk3YLBO1+bRuxoPV426WiJGL1y4UFNT07FjR9dbq6j06dMnKSmJKzbd3Nwe/uP3+sc//rFq1apz587t2rXrhRdeMPZ4iU2gf36t2yuvxIeGpt24EfzoXY2n7qDeEjGalZUFoE+fPoYtYrE4KipqwIABjchQAHZ2dgsWLACwevVqumqFNA7FqHWTy4H734hvQnUH9ZY4N8qdGK0fo00XHR3dunXr06dP79+/34jNEttBMWrduHX1zByj5ZauRg3zS0bh4ODw9ttvA+AWKyHkcVGMWjGVChoNxGKY+eJxC54bFQrn9O8/Pyion3GbnTVrlq+v78mTJw8dOmTcloktoBi1YhY5ogegPXq0S26ua1mZmftVKrFnz+g//1zXuXNn47YsEonefPNNAGvWrDFuy8QWUIxasdJSADD/M4QOrV+//aWX7O+3UL9JZWWBMfTubZL7/ufOnevh4XH48OFjx44Zv3XSolGMWjFLVaNyuRyA+Z8Bl5UFAEadXrrN1dWVeyLTe++9Z5IOSMtFMWodLl6EXl/3urAQlZX44w8EB+PIEaxejbNnzTqY0tJSAJ5mz+/sbAAw6vTSHWJjY8Vi8Y8//pienm6qPkhLRDFqHSZNgkpV93rBAmRmIiQEO3bgyScREoKoKPONRKPRVFRU2NnZubg04Hl5RsVVo6aLUU9Pzzlz5oAKUvKYKEatVe/e+M9/cOOGufs1HNGbed14xuqKbtPFKIB//etfIpFoz5493JVVhDQExajV2LQJH36IDz/E+fMA4OCApUsxf765h8Ed0Zv/xGh+PsrLERAAnyYsUX0vvV4fGxt78OBB7q2vr+/MmTMZY8uWLdPpdMbsibRcFKNWo3t39OyJnj1huOlxwgQoFDhyxKzD4KpR858YNcX8kk6ni46O3rBhw7Rp01S3TpqMHz/ezs4uLS3Nz89v8uTJW7duvXbtmjF7JS0OxajVGDECo0Zh1Cj4+9/e+PHHWLwYAE6exKefwgw3hVuqGpXLIRbj1rpORqDVal955ZXExERnZ+ft27eLxWIAGRkZkyZNqq2tra2tlcvlO3bsmDVrVtu2bYcMGbJ69erMzEy6757cByPWoG9fVlZW93rKFHb0KAsOrnu7fDnr3p1168YANno0u3LFhMPIzMwMDw93d3fv0KHD1atXTdhTPbt3s6NHGWNMr2c7drCiIiO0qVarJ06cCMDNze23337jNh47doxb3yQyMrK6uvrChQsfffTRyJEjHRwcDL8v/v7+b7+9eceO2/87CKEYtQ7p6UyrrXt99iwrK2MnT9a9ra5maWksKYl5ezOAubkxmcz4Azh8+HBERAQXJc7OzgA8PDy++uor4/d0j8mTWceOTKFgjLFp025/8EarrKx85plnuI9w8lZzv/76K1eQTpkyRaPR1N+/qqoqJSUlNjY2MDAQwLBhhwEmELDgYBYXxzIymF5/e+erV1lhYd3roiImlzd1tKT5oxhtOa5fZxMmMIAB7LnnmLGKxdTU1BEjRnABKhaLY2Njs7Kyxo8fz20ZM2aMqcvSyZPZkiVszhzGjBGjFRUV3Mfx8/M7c+YMt3H//v3cY5anTZtWW1v7kB/PysrasEE+bBgTCuv+qAHWrh2bPZslJ7PKSrZ0KQsMZCoVY4wtX87M8g8NsTCK0ZYmKYl5ejKA+fiw775rfDt6vT45OXnQoEFcXHp5ecXFxZWWltbrKMnDwwOAj4/Pd03p6VEmT2bZ2eypp9jJk02NUYVCwT1EpFWrVjk5OdzG5ORk7rB91qxZOp2uwU2xpCT2yivMz+92njo5sbffZhMnsvnzGaMYtRkUoy1QQQGLiKj7xZ49u1z+mAeWOp0uOTk5OLhuKWgfH5+4uLiy+50LLCgoMBzpR0VFlZSUGOkTMMaYXs927WLfflsXozk5bMgQNnUqO3mSffMNu/Owu0FKS0tDQ0MBtGvX7uLFi9zGb775xs7ODsD8+fP19Q/OH0dODpNKWUQECw5mS5eynTtZeDg7c4Zi1FZQjLZMej2TyZirK+vbN9bPz2/37t0N+SmdTpeUlNS9e3cuGdu2bZuQkFBVVWXY4fTp0zdv3ryzI71MJuPuaPL399+zZ0/TB6/TseRkNmAAA1irVuyFF1h2NmOMLVjAPDxYfDwDWGAgk8luny9+pOvXr3OrlHbt2rXw1snLL7/8UiAQAJBIJE0fNmNMrWZLl7Lvv2d//MGefJJi1FZQjLZkeXmlTzzxBJeJr776qlKpfNCearU6MTGxS5cu3M7t27dPSEiorq427HDq1KmoqCgej7dw4cJ7f/zvv/8eNmyYoSytf+z/WDQa9vnnrGvXulI6MJBt3Mhefpnl5jLGmErFundnmzezHj3qdujfnx048OhmL1++zH20Hj16GM7kbt68mXuG3YoVKxo32vviYpQx9vrrLCiIYtQmUIy2cFy1KBKJAAQGBv7888937VBTUyOTydq0qXsoXqdOnWQyWf1plqNHj3Lz2twc/bvvvvvIjtq1a3fo0KHHGqdazRITWefOdfnYoQNLSGD1YvwOOh1LSmIdOtTtPGQIS019YMv5+fmdOnUC0L9/f0MpvXbtWgA8Hu+jjz56rHE+kiFGlUoWEEAxahMoRm1Cbm7uwIEDueCIiYlRqVSMMZVKlZCQ0KpVKy4ig4KCEhMTtfWOk1NTUyMjI7nvuri4xMbGFj3qos2zZ8/e29HDVVZWbt2aGhBQl4k9e7KvvmrQ0bpazWQy5utb94MRESwr6z67paamikSiwYMHK7hrphiTSqXcCDdu3Pjobh7T1at112YVFrJPP6ULnmwCxaitqK2tXbVqlb29PYCOHTu++uqrhhs6Bw0alJycXH+CJSUlJSwsjPuuq6urRCJp+DxVbW2tVCrlOurQocORI0cetKchxwUC+/btNX36sMTExzjdeasRJpUysZgB7KmnDkZFReXn59+1z/Hjxw2BvnTpUgACgWDbtm2P19PjqK5mDg6Mz2eNPb1BrAnFqG3Jzs4eMGCA4RL68PDw5ORkw3e5OfqQkJBHztE/UlZWVv/+/QHw+fzY2Niampr635XL5XFxcdz1UgDCwsIOHsxp7Dw5Y4xdvcreeEMjFvsBEIlECxcuNNSeBnq9ft68eQDs7e137NjR+M4a5oknGMD27jV1P8TyKEZtjlqt5u6IT0pKMmzk5uh79OjB5Zqfn59UKq2srGxKRxqNRiqVcpcT9ezZMz09nTFWXFwcFxfn7u7OdXRXjjfR+fPnuXkw7g4lqVRquMxAq9VGR0cDcHBw2LVrl7F6fIglSxhQdwEpadkoRm0RV4oajnMVCkXHjh25XOvQocOWLVvuKh6b4vjx4926dQNgZ2cXHh7OzUEBGDVq1LFjx4zVS32///674bar1q1by2Sympqal156iStUf/rpJ1N0yklPZ//+d939Yz/9xAAWEmK63khzQTFqc9RqNXdgW3/js88+27Fjx7vm6I2lurpaIpHweLzWrVvzeLzIyMiTTb8x/lEOHjzInb4AwC044urqmvqQGX1jGDuWASwxkTHGKiuZvT0TCGgRk5aPYtTmFBUVcXdD1t9YXFzc8PsgGyc8PByAKSbHH0Sv1yclJXXq1KlNmzZisfj48eOm7vH99xnAoqPr3g4ezAC2f7+puyUWRuuN2pz7rrvs4+PDXYtuOlqtFoDhHlMz4PF4UVFRp0+fLikpqaioMPrT7e81fDiA2wtpc3ckmHldbWJ+FKM2x2zrLufm5u7cufM898wTyz1P1MXFJSwsjDFmhgfQ9+sHd3fk5aGwEKAYtRkUozbHbE8B2bNnz6RJkxITE+v3a/5l8wFwN6oeMX2eCQQYMgQAUlMBIDwc9vZQKmsqKqpN3TWxIIpRm2O2OKtffur1+rKyMj6fb7jUyZzMFqMAhg0Dn4/MTBUAsRhDhow/d84pLS3VDF0TS6EYtTlmO7iuX/aWlZXp9Xp3d3duRSUzGzx4sKOj45kzZ8rKykzd19NP54nF7fftG8i9DQnpCuDo0aOm7pdYEMWozTHbudH6Za+lnifKcXR0DAkJ0ev1Zjk92k6vLz1//jx3RQRXCP/666+m7pdYEMWozTFbotUvey14YpQzfPhwmOW4XigUcgvsc5E9dOhQgUCQnp5eVVVl6q6JpVCM2hyLVKOWmqY3MGdVWP9UrJubW9++fTUazYkTJ8zQNbEIilGbY+ZqtP5BvQWr0SFDhtjb2586dUqpVJq6r7tmtMw5wUUsgmLU5pgt0RQKBQBuGSeLV6MikSg4OFin06WlpZm6r4EDBzo7O+fm5hYXF4Ni1AZQjNoc8yRaeXm5RqMRi8XcwqNmO5PwEGaLM3t7+/fee2/79u3cEjBDhw7l8/knTpyoqakxddfEIihGbY55YvSu3LTsTD3HnFVhbGzs5MmTuRj19PQMCAjQ6XTjxo3btm3bjRs3zDAAYk5CSw+AmFVlZWVNTY1IJHJycjJpR3flZnOoRp944gmhUJiRkaFSqcRisXk6ZYy9+eabV65ccXV1TUlJSUlJAdCzZ8+xY8dGREQMHz5cKKTfQatH1ahtMfO1982qGnVxcenfv79WqzXbpDlj7I033li/fr29vX18fPymTZvGjBkjEolyc3Pj4+NHjhwZEBAwffr0b77ZXlpqnhERk6AYtS0WuRPUnP0+nDmP63U63YwZMzZt2iQSifbu3Tt79uw5c+bs27dPLpenpKRIJJIePXrcvHnzq6++Wr78e19fhIRg4UIcOwbGzDA6YkwUo7blvgfX3ISycd2VmxafqeeYLUY1Gs3//d//JSYmOjs779271/CEagCOjo4RERFSqTQ3N/fPP//88MMPhw+fKxTijz8QH4+hQ9GmDWbOxPffQ6UCgF9+QUhI3eujR7FiBd58E2fO1LW2fj127TL1pyGPQDFqW+49uL506VKXLl1mzZpVUVFhxI6aZzXK3VP0+++/m/SeIrVaPWXKlO+++87d3T0lJeXpp59+0J7dunV76623ZLJhJSXYtQszZ6JNGxQV4dNP8cIL8PbGiBHIzoZKhbg4AKiqglyO68dkHSIAAAcBSURBVNdhmPMvLUV5uek+CmkQilHbwqUb99A3TlpaWnV19datWwcMGGDEayqHDh26ZMkSrvrTarUqlUooFLq6uhqr/ca57z1FhYWFYWFhK1euzMjI0Ov1Teyiqqpq7Nixu3fv9vT0/Omnn7gbQx/JxQUTJmDrVhQWIi8PCQmIiABj+OUXiESYMAGnTuHUqdv7X7uG/Hzk58P0a62QBrDw6vvEvM6fPz9q1CiBQCCRSDQaDbcxOzvb8DDkmJiYJj4Q9F7cJT6+vr7GbbZx3nrrLQDLli0zbNmyZYvh18Hb2zsqKioxMbG0UQ+YV6lUTz31FAA/P7+srKwmDrW0lCUns+RkJpGw06dZeDjbv5+98QabMoVNmMBiYlhMDAsOZtu2NbEf0lQUozYnNjaWq0ZDQ0Nzc3O5jfd9GLKx5ObmAujevbsR22y03bt3Axg2bJhhS1VVFTfnwz3BlCMQCIKDg+Pi4rgStSEtKxSKsLAwAG3btr1w4YKxBszFKGPszTfZ1Kl1MXriRN134+IoRi2PYtQWpaamdurUCYCjo6NUKtVqtdz2kydPdu/eHYBQKJRIJGq12ijdffDBBwC6du1q6qfmNYRcLufz+XZ2dkePHr13PHl5eQkJCREREdzNVxw/P7/p06cnJSUplcoHNXvjxo2+ffsCaN++/cWLF404YEOMKpWsdev7x+i337ING5jxnopNHg/FqI1SKpUxMTFcWTp48ODz589z27mHIXOLKwcFBWVmZja6C71en5ycHBoailt31g8ZMsSIZVqjLVmyJDAwEICXl1dUVJRMJrt27dpd+yiVyu+++y46OrpVq1aGPHVwcBg5cuSVK1fu2vnatWu9e/cG0K1bt8LCQuOONjf39rNFf/6Z7dnDtm1jly7VbfnxR3bwIDt+nO3dy/77X+P2TBqKYtSmHThwoE2bNgCcnJykUqmhOvvtt9+6dOkCwM7OLi4uzlCuNpBWq/3mm2+CgoK49PH394+Ojvbz8wPg4uKyefPmBh4mm4hOp3v99dc7duxY/xA+PDx8zZo1mZmZ944tJydHKpVGRETY2dmJxeK7ivSCggLuz6pnz55FRUVm/Bx3+PRT9ssvlurc1lGM2jqFQhETE8OlSUREREFBAbe9srJSIpFwT10eNGjQuXPnGtKaRqNJTEzkzgwACAwMTEhIqKqququjkSNHXr582YSfqmHy8vJkMllkZKSDg4MhUn19fblDeIVCcdf+JSUlR44cqb8lPz+fi+MBAwbcvHnTjGO/w4ED7JNPLNU5oRgljDHG9u3bxx29urq6ymQyw/aDBw9y5apIJNq3b99DWlCr1YmJiVxdxp0iTEhIqK6uvmu3HTt2+Pj43NuRZVVWVqakpMTGxrZt2/auElUqlT5oluncuXOtW7cGEB4eXlZWZv5hc86cYc88wyQS9uOPlhqCraMYJXVu3Ljx/PPPcwkyatQowxlA7iyqt7f39evX7/uDNTU1MpmMS1sAnTp1kslktbW1D+ro+vXr48eP53YeO3bstQc0ayn3nWVq3759TExMUlJSeXk5t1tOTg73D8+wYcMMG4ltohgld0hKSuLuNXJ3d69fLd43Q1UqVUJCgmESJigoKDExsYEnUpOSkjw9PT0CAp4/fXqn5Q6HH6K0tHT79u0vvfSSr6+vIU+dnJxGjRr1zjvvcDdojR49mjtlQWwZxSi527Vr18aNG8elxqRJk+57yk+pVEqlUsO9nv37909KSnrciaPCwsJ3U1ODMzKCMzIW5uWVPbiAtTjDLBO3rh2fz7e3t3/++eeNdU0YsWo8RuvJkPv54osvXn/9dZVK5evru2XLlokTJ3Lbb968uWnTpo8//ph75nt4eLhEIhk7dmyjO/pBLo8vLKzS6TyFwkXt2j3l7m6cD2AaxcXFBw4c+OuvvyIjI4ODg2m1UAKAYpQ8UEFBQXR09C+//AIgKipq1apVn3/++YYNG7h1PcLDw1esWDFixIimd3RNo1lx6VKGSgUgwsNjcWCgK8UTsR4Uo+Rh9Hr9xo0bFy1aVFVV5ejoWFNTw+Pxxo0bt3Tp0pCQECN2xIBdJSUfFRZW6/XednZL2rXrIRJdVqu577ZzcPCyszNid4QYEcUoebQLFy7MmzevR48e165dW7x4seG6eqMrqKlZfulSdmUlDxjv41OsVge5uAAY6ubWXSQyUaeENBHFKGle9MC3xcV75fJILy8w9qKfn6VHRMgjUIyS5kjH2M6Skp8VCq4InRMQ4MintXFJM0Un8klzJODxAPQSiUZ7egKwr7fONCHNDcUoab587Oy60ilR0uzRgRIhhDQJnRslzZRSq2WAO11ASpo9ilFCCGkSOqgnhJAmoRglhJAmoRglhJAmoRglhJAmoRglhJAm+X8U1V9jMIYuMgAAAjB6VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHu/b+09BiDgAWJGBgiQB2IlIG5gZEvQANLMLGwJFiCakQUhAKUVDJBoJgSNrg7TIFwmYlGBoRRdhlNBAeR+KMWuABFmZodoQNAQCSYMCQ4FkH//M8JoAQWQOCsLNwNHAoNgBhODuAIjUwYTo3gCE3MCE68CM2cGE7NEAgsrAysbA5scAztHBhO7cAK7mAKHCAMnVwKneAIXdwYTN08Cj0QGE4+kAi9fBhOvQAKfVAK/VAYTv3SCgHQGk6BQgqAog5BwBpOYHIOMHIOsHIMICysjEzOnOBu7sJAgAwcbFzePBDMnG58Uv7QArzgsghjkG6S793eYX9gP4nhwstvf/c1gD2Jz32FwaM81BbNzt2s5RKqpgNXYzvI/MLt0ogOI/bYn7MAqbWcw+3PFtAMeAZJgNkNq9oEfqjvA6tkZRA+k3/MAs6N+nLIXFbsOZvO++2Hfd8DjAIituDbCYW5JMpht+KXPQfOzApi9RU3PIYyBCWI+T7tDjyQrmM0c1+KgsHQqmB3255u9WE8wmP2QYeb+wNvuYL2ZT5UObN5WCGZvCC860HHJGswO5+U7cFreDOyvzaU2ttX7a8Hii7PnHnDbLQF226GdbXYdjJVg9pGyZgfv6nYw245/r4PFcog5HpvmOjTsiwTbe+WEhkOrxBQwm0s15IBmhRfYfMFLJw9cZ2sEs70/zTzwxikNzBYDAFHjlN45N0kPAAACMnpUWHRNT0wgcmRraXQgMjAyMC4wOS4xAAB4nJ1WS27cMAzd+xS6wAgkRVHissj0AxRJgBToHbrqprl/qc/IHiQBYg4MDJ9pPvMvy+vr3/hlC+33cv35519YP7puW0gYEocA716qGn4TADT7C0aoUockJKVxQDQthIfwEcXx2oZFppKnBKn6WCgCNr+bbYHq9IWiSGksF4jCSC6WS4rEIw6OmbN4WVKmHlGKwJp9LGzZoDRiS5qdLClKqTAqbaH5snsxD6jiyG6p7MtLwJhrLrPrKrCXRZnriA2TOLvOalR7fY0lZwYfC0eWkkaGMrJ7AgohzllImLy+EMHsFyjqnCNuOc1DkiL+GpHKzDNkH4t1CWpOs9JEvuy2yvCNpRRnvzTbKjL4NLF7jgh1Tk9BPObl25m9CywwvFK567rPs9h+UdS5MbPKcaafzvhCkuZm0ELFx2JdB5VGzcGWhI8lR4WxpVqNCL2+KPWNab3LcwOfZ7HzKPXN0OZo8p1maSfJ2ipFQQ8sz29Z8AMWsRkUHXMJcOfLCRaO1Yo0bKvenWq/3rK88yGydW4db+gAjY5uoJ2YU2P30tLQUZM68wK4Aw4Iy4YD5aUxSRYwqSxQ2jfTDdTuG90AwUHTumACDbRs7I14BLujdrt9gww2k3ARmNR8owWWbxYM7hoDy1G7TTuQDmiBujSlg6mpAVeuDRAtoD248ZhFtueA9AAS7OAxhIcf37uNPWNTGpra/pvm69N1+w9/eaUC90aVpwAAAXh6VFh0U01JTEVTIHJka2l0IDIwMjAuMDkuMQAAeJwlkjtuIzEQRK+yoQRQRP8/cCjAoTfY0HA0uU7gw281hQGImQJfdbE4z+fz3+377+Pn/l6/Lr5un/fr9njJhfXS64VH73iBcN2+7i98zJaL//zeHrrFNHvZdvPg9QFFXdSXbrJ2g2I7SSSWbG13OUoxlS7a1W3eb4wtA1I2VQek2EpRvXgTFb255tZeD9reEVQHjCyy9eBtWjEgBkmxzrYsC7OjCbcff2YThQTfAjtkSARS0JZQ1hiyU6JGckkrB+ikZQBlE6tN+qRKOkoKM+OEpCy5PmyLkOoI2WOD5FLEaMXQhY+AOVYoLjKMxyMUI0eQbIRhIO0FRMnfcyPSfMKBEJ4tXp7nAEWIPYxNi2gF9ok5oMtnj253HV/bFqm8UImzFcrxjcr5KK1CJy7uBzGnIy/MnLbQn9qxFsEMVEMWxHTMG4fh0zN+hCF1Z067c0M593LcLWXdf/8DMjWCK33TS9MAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f1a6309bb20>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f0bdd8b0120>"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10964,7 +11225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -10984,7 +11245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -11004,7 +11265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -11024,7 +11285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
@@ -11051,7 +11312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
@@ -11071,7 +11332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {

--- a/opencadd/databases/klifs/core.py
+++ b/opencadd/databases/klifs/core.py
@@ -280,7 +280,7 @@ class KinasesProvider(BaseProvider):
     all_kinases(groups=None, families=None, species=None)
         Get all available kinase names (optional: select kinase group, family and/or species).
     by_kinase_klifs_id(kinase_klifs_ids)
-        Get kinases by one or more kinase IDs.
+        Get kinases by one or more kinase KLIFS IDs.
     by_kinase_name(kinase_names)
         Get kinases by one or more kinase names (KLIFS or HGNC name).
 
@@ -400,7 +400,7 @@ class KinasesProvider(BaseProvider):
 
     def by_kinase_klifs_id(self, kinase_klifs_ids):  # TODO *kinases_ids
         """
-        Get kinases by one or more kinase IDs.
+        Get kinases by one or more kinase KLIFS IDs.
 
         Parameters
         ----------
@@ -415,7 +415,7 @@ class KinasesProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the kinase IDs exist.
+            Remote module: If none of the kinase KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -457,11 +457,11 @@ class LigandsProvider(BaseProvider):
     all_ligands()
         Get all available ligands.
     by_kinase_klifs_id(kinase_klifs_ids)
-        Get ligands by one or more kinase IDs.
+        Get ligands by one or more kinase KLIFS IDs.
     by_kinase_name(kinase_names)
         Get ligands by one or more kinase names (KLIFS or HGNC name).
     by_ligand_klifs_id(ligand_klifs_ids)
-        Get ligands by one or more ligand IDs.
+        Get ligands by one or more ligand KLIFS IDs.
     by_ligand_expo_id(ligand_expo_ids)
         Get ligands by one or more Ligand Expo IDs (3-letter codes), i.e. the chemical component
         identifiers as defined by Ligand Expo (http://ligand-expo.rcsb.org/) and used in the PDB.
@@ -513,7 +513,7 @@ class LigandsProvider(BaseProvider):
 
     def by_kinase_klifs_id(self, kinase_klifs_ids):
         """
-        Get ligands by one or more kinase IDs.
+        Get ligands by one or more kinase KLIFS IDs.
 
         Parameters
         ----------
@@ -528,7 +528,7 @@ class LigandsProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the kinase IDs exist.
+            Remote module: If none of the kinase KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -559,7 +559,7 @@ class LigandsProvider(BaseProvider):
 
     def by_ligand_klifs_id(self, ligand_klifs_ids):
         """
-        Get ligands by one or more ligand IDs.
+        Get ligands by one or more ligand KLIFS IDs.
 
         Parameters
         ----------
@@ -610,11 +610,11 @@ class StructuresProvider(BaseProvider):
     all_structures()
         Get all available structures.
     by_structure_klifs_id(structure_klifs_ids)
-        Get structures by one or more structure IDs.
+        Get structures by one or more structure KLIFS IDs.
     by_ligand_klifs_id(ligand_klifs_ids)
-        Get structures by one or more ligand IDs.
+        Get structures by one or more ligand KLIFS IDs.
     by_kinase_klifs_id(kinase_klifs_ids)
-        Get structures by one or more kinase IDs.
+        Get structures by one or more kinase KLIFS IDs.
     by_structure_pdb_id(structure_pdb_ids)
         Get structures by one or more structure PDB IDs.
     by_ligand_expo_id(ligand_expo_ids)
@@ -748,7 +748,7 @@ class StructuresProvider(BaseProvider):
 
     def by_structure_klifs_id(self, structure_klifs_ids):
         """
-        Get structures by one or more structure IDs.
+        Get structures by one or more structure KLIFS IDs.
 
         Parameters
         ----------
@@ -763,7 +763,7 @@ class StructuresProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the structure IDs exist.
+            Remote module: If none of the structure KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -771,7 +771,7 @@ class StructuresProvider(BaseProvider):
 
     def by_ligand_klifs_id(self, ligand_klifs_ids):
         """
-        Get structures by one or more ligand IDs.
+        Get structures by one or more ligand KLIFS IDs.
 
         Parameters
         ----------
@@ -786,7 +786,7 @@ class StructuresProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the ligand IDs exist.
+            Remote module: If none of the ligand KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -794,7 +794,7 @@ class StructuresProvider(BaseProvider):
 
     def by_kinase_klifs_id(self, kinase_klifs_ids):
         """
-        Get structures by one or more kinase IDs.
+        Get structures by one or more kinase KLIFS IDs.
 
         Parameters
         ----------
@@ -809,7 +809,7 @@ class StructuresProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the kinase IDs exist.
+            Remote module: If none of the kinase KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -927,9 +927,9 @@ class BioactivitiesProvider(BaseProvider):
     all_bioactivities()
         Get all available bioactivities.
     by_kinase_klifs_id(kinase_klifs_ids)
-        Get bioactivities by one or more kinase IDs.
+        Get bioactivities by one or more kinase KLIFS IDs.
     by_ligand_klifs_id(ligand_klifs_ids)
-        Get bioactivities by one or more ligand IDs.
+        Get bioactivities by one or more ligand KLIFS IDs.
 
     Notes
     -----
@@ -976,7 +976,7 @@ class BioactivitiesProvider(BaseProvider):
 
     def by_kinase_klifs_id(self, kinase_klifs_ids):
         """
-        Get bioactivities by one or more kinase IDs.
+        Get bioactivities by one or more kinase KLIFS IDs.
 
         Parameters
         ----------
@@ -991,7 +991,7 @@ class BioactivitiesProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the kinase IDs exist.
+            Remote module: If none of the kinase KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -999,7 +999,7 @@ class BioactivitiesProvider(BaseProvider):
 
     def by_ligand_klifs_id(self, ligand_klifs_ids):
         """
-        Get bioactivities by one or more ligand IDs.
+        Get bioactivities by one or more ligand KLIFS IDs.
 
         Parameters
         ----------
@@ -1014,11 +1014,36 @@ class BioactivitiesProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the ligand IDs exist.
+            Remote module: If none of the ligand KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
         raise NotImplementedError("Implement in your subclass!")
+
+    def by_ligand_expo_id(self, ligand_expo_id):
+        """
+        Get bioactivities by one or more ligand Expo IDs.
+
+        Parameters
+        ----------
+        ligand_expo_id : str or list of str
+            Ligand Expo ID(s).
+
+        Returns
+        -------
+        pandas.DataFrame
+            Bioactivities (rows) with columns as described in the class docstring.
+
+        Raises
+        ------
+        bravado_core.exception.SwaggerMappingError
+            Remote module: If none of the ligand Expo IDs exist.
+        ValueError
+            If DataFrame is empty.
+        """
+        raise NotImplementedError("Implement in your subclass!")
+
+    
 
 
 class InteractionsProvider(BaseProvider):
@@ -1032,11 +1057,11 @@ class InteractionsProvider(BaseProvider):
     all_interactions()
         Get all available interaction fingerprints.
     by_structure_klifs_id(structure_klifs_ids)
-        Get interactions by one or more structure IDs.
+        Get interactions by one or more structure KLIFS IDs.
     by_ligand_klifs_id(ligand_klifs_ids)
-        Get interactions by one or more ligand IDs.
+        Get interactions by one or more ligand KLIFS IDs.
     by_kinase_klifs_id(kinase_klifs_ids)
-        Get interactions by one or more kinase IDs.
+        Get interactions by one or more kinase KLIFS IDs.
 
     Notes
     -----
@@ -1088,7 +1113,7 @@ class InteractionsProvider(BaseProvider):
 
     def by_structure_klifs_id(self, structure_klifs_ids):
         """
-        Get interactions by one or more structure IDs.
+        Get interactions by one or more structure KLIFS IDs.
 
         Parameters
         ----------
@@ -1105,7 +1130,7 @@ class InteractionsProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the structure IDs exist.
+            Remote module: If none of the structure KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """
@@ -1113,7 +1138,7 @@ class InteractionsProvider(BaseProvider):
 
     def by_ligand_klifs_id(self, ligand_klifs_ids):
         """
-        Get interactions by one or more ligand IDs.
+        Get interactions by one or more ligand KLIFS IDs.
 
         Parameters
         ----------
@@ -1136,7 +1161,7 @@ class InteractionsProvider(BaseProvider):
 
     def by_kinase_klifs_id(self, kinase_klifs_ids):
         """
-        Get interactions by one or more kinase IDs.
+        Get interactions by one or more kinase KLIFS IDs.
 
         Parameters
         ----------
@@ -1153,7 +1178,7 @@ class InteractionsProvider(BaseProvider):
         Raises
         ------
         bravado_core.exception.SwaggerMappingError
-            Remote module: If none of the kinase IDs exist.
+            Remote module: If none of the kinase KLIFS IDs exist.
         ValueError
             If DataFrame is empty.
         """

--- a/opencadd/databases/klifs/core.py
+++ b/opencadd/databases/klifs/core.py
@@ -1043,8 +1043,6 @@ class BioactivitiesProvider(BaseProvider):
         """
         raise NotImplementedError("Implement in your subclass!")
 
-    
-
 
 class InteractionsProvider(BaseProvider):
     """

--- a/opencadd/tests/databases/test_klifs_local_remote.py
+++ b/opencadd/tests/databases/test_klifs_local_remote.py
@@ -303,7 +303,10 @@ class TestsFromLigandIds:
         with pytest.raises(NotImplementedError):
             LOCAL.bioactivities.by_ligand_klifs_id(ligand_klifs_ids)
 
-        check_dataframe(result_remote, DATAFRAME_COLUMNS["bioactivities"] + [("ligand.klifs_id (query)", "int32")])
+        check_dataframe(
+            result_remote,
+            DATAFRAME_COLUMNS["bioactivities"] + [("ligand.klifs_id (query)", "int32")],
+        )
 
         # Interactions
         result_remote = REMOTE.interactions.by_ligand_klifs_id(ligand_klifs_ids)
@@ -483,8 +486,10 @@ class TestsFromLigandPdbs:
         with pytest.raises(NotImplementedError):
             LOCAL.bioactivities.by_ligand_expo_id(ligand_expo_ids)
         print(result_remote)
-        check_dataframe(result_remote, DATAFRAME_COLUMNS["bioactivities"] + [("ligand.expo_id (query)", "string")])
-
+        check_dataframe(
+            result_remote,
+            DATAFRAME_COLUMNS["bioactivities"] + [("ligand.expo_id (query)", "string")],
+        )
 
     @pytest.mark.parametrize("ligand_expo_ids", [1, "XXX"])
     def test_by_ligand_expo_id_raise(self, ligand_expo_ids):

--- a/opencadd/tests/databases/test_klifs_local_remote.py
+++ b/opencadd/tests/databases/test_klifs_local_remote.py
@@ -303,7 +303,7 @@ class TestsFromLigandIds:
         with pytest.raises(NotImplementedError):
             LOCAL.bioactivities.by_ligand_klifs_id(ligand_klifs_ids)
 
-        check_dataframe(result_remote, DATAFRAME_COLUMNS["bioactivities"])
+        check_dataframe(result_remote, DATAFRAME_COLUMNS["bioactivities"] + [("ligand.klifs_id (query)", "int32")])
 
         # Interactions
         result_remote = REMOTE.interactions.by_ligand_klifs_id(ligand_klifs_ids)
@@ -458,7 +458,7 @@ class TestsFromLigandPdbs:
     Test class methods with Ligand Expo IDs as input.
     """
 
-    @pytest.mark.parametrize("ligand_expo_ids", ["PRC", ["PRC", "1N1"], ["PRC", "1N1", "XXX"]])
+    @pytest.mark.parametrize("ligand_expo_ids", ["1N1", ["1N1", "PRC"], ["1N1", "PRC", "XXX"]])
     def test_by_ligand_expo_id(self, ligand_expo_ids):
         """
         Test class methods with Ligand Expo IDs as input.
@@ -477,6 +477,14 @@ class TestsFromLigandPdbs:
 
         check_dataframe(result_remote, DATAFRAME_COLUMNS["structures"])
         check_dataframe(result_local, DATAFRAME_COLUMNS["structures"])
+
+        # Bioactivities
+        result_remote = REMOTE.bioactivities.by_ligand_expo_id(ligand_expo_ids)
+        with pytest.raises(NotImplementedError):
+            LOCAL.bioactivities.by_ligand_expo_id(ligand_expo_ids)
+        print(result_remote)
+        check_dataframe(result_remote, DATAFRAME_COLUMNS["bioactivities"] + [("ligand.expo_id (query)", "string")])
+
 
     @pytest.mark.parametrize("ligand_expo_ids", [1, "XXX"])
     def test_by_ligand_expo_id_raise(self, ligand_expo_ids):


### PR DESCRIPTION
## Description

The KLIFS OpenAPI offers one more API: Get bioactivities by ligand Expo ID. 
Add this functionality to the `remote` module of `opencadd.databases.klifs`.

## Todos

  - [x] Add `Bioactivities.by_ligand_expo_id` (`remote` module)
  - [x] Add unit test
  - [x] Rerun KLIFS tutorial

## Questions

None.

## Status

- [x] Ready to go