### PR TITLE
Enable pocket retrieval from local pdb files

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -31,6 +31,8 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - nbsphinx
+  # Temporary fix for issue #65
+  - parso 0.8.1
 ## For Jupyter lab extensions, run:
 # conda install nodejs
 # jupyter labextension install @jupyter-widgets/jupyterlab-manager nglview-js-widgets @jupyterlab/toc

--- a/docs/tutorials/databases_klifs.ipynb
+++ b/docs/tutorials/databases_klifs.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1896,7 +1896,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e45b9560388648f1be349cc875cb56e5",
+       "model_id": "a9f5011d651847b89411360165303c92",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2016,7 +2016,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a7a2708cce1440db9515da3a9504836a",
+       "model_id": "e9c4940071424d93b26674b292bd351c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2136,7 +2136,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6d4e0c78a13b4e33bc9fb9170cc1b62a",
+       "model_id": "28663dc6967d42ada1bc88beb1052b8e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2180,7 +2180,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "96085dfe2e50484c9112a48ba62819a7",
+       "model_id": "0e4fe9af47f04b078c02c5d2fbfd4c81",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2583,24 +2583,24 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3562</th>\n",
-       "      <td>3853</td>\n",
-       "      <td>FJ0</td>\n",
-       "      <td>2-(2-methylpyridin-4-yl)-N-[2-morpholin-4-yl-5...</td>\n",
-       "      <td>O=C(Nc1c(nc2N=C(Oc2c1)N3CCOCC3)N4C[C@H](O)CC4)...</td>\n",
+       "      <th>3580</th>\n",
+       "      <td>3871</td>\n",
+       "      <td>Q6G</td>\n",
+       "      <td>Selpercatinib</td>\n",
+       "      <td>O(c1ncc(cc1)CN2[C@H]3CN(c4ncc(cc4)C=5C=6N(N=CC...</td>\n",
        "      <td>InChI not available</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3563</th>\n",
-       "      <td>3854</td>\n",
-       "      <td>CHU</td>\n",
-       "      <td>N-(3-fluoro-4-{[4-methyl-2-oxo-7-(pyrimidin-2-...</td>\n",
-       "      <td>S(=O)(=O)(Nc1nccc(c1F)CC=2C(=O)Oc3c(ccc(Oc4ncc...</td>\n",
+       "      <th>3581</th>\n",
+       "      <td>3872</td>\n",
+       "      <td>Q4J</td>\n",
+       "      <td>Pralsetinib</td>\n",
+       "      <td>FC=1C=NN(c2ncc(cc2)[C@@H](NC(=O)C3(OC)CCC(c4nc...</td>\n",
        "      <td>InChI not available</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>3564 rows × 5 columns</p>\n",
+       "<p>3582 rows × 5 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2608,31 +2608,31 @@
        "0                   1            IHZ   \n",
        "1                   2            477   \n",
        "...               ...            ...   \n",
-       "3562             3853            FJ0   \n",
-       "3563             3854            CHU   \n",
+       "3580             3871            Q6G   \n",
+       "3581             3872            Q4J   \n",
        "\n",
        "                                            ligand.name  \\\n",
        "0     5-[(2-methyl-5-{[3-(trifluoromethyl)phenyl]car...   \n",
        "1     3-{2-[5-(difluoromethyl)-2H-thieno[3,2-c]pyraz...   \n",
        "...                                                 ...   \n",
-       "3562  2-(2-methylpyridin-4-yl)-N-[2-morpholin-4-yl-5...   \n",
-       "3563  N-(3-fluoro-4-{[4-methyl-2-oxo-7-(pyrimidin-2-...   \n",
+       "3580                                      Selpercatinib   \n",
+       "3581                                        Pralsetinib   \n",
        "\n",
        "                                          ligand.smiles  \\\n",
        "0     FC(F)(F)c1cc(NC(=O)c2cc(Nc3cncc(c3)C(=O)N)c(cc...   \n",
        "1     S1C=2C(=NNC2C=C1C(F)F)C=3Nc4c(ccc(c4)C(O)(CC)C...   \n",
        "...                                                 ...   \n",
-       "3562  O=C(Nc1c(nc2N=C(Oc2c1)N3CCOCC3)N4C[C@H](O)CC4)...   \n",
-       "3563  S(=O)(=O)(Nc1nccc(c1F)CC=2C(=O)Oc3c(ccc(Oc4ncc...   \n",
+       "3580  O(c1ncc(cc1)CN2[C@H]3CN(c4ncc(cc4)C=5C=6N(N=CC...   \n",
+       "3581  FC=1C=NN(c2ncc(cc2)[C@@H](NC(=O)C3(OC)CCC(c4nc...   \n",
        "\n",
        "                  ligand.inchikey  \n",
        "0     SAAYRHKJHDIDPH-UHFFFAOYSA-N  \n",
        "1     CQZZZUNOWZUNNG-UHFFFAOYSA-N  \n",
        "...                           ...  \n",
-       "3562          InChI not available  \n",
-       "3563          InChI not available  \n",
+       "3580          InChI not available  \n",
+       "3581          InChI not available  \n",
        "\n",
-       "[3564 rows x 5 columns]"
+       "[3582 rows x 5 columns]"
       ]
      },
      "execution_count": 36,
@@ -2770,7 +2770,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ecd173ce9344af1a3395a0a7ab2dc59",
+       "model_id": "54967774829044fca7d8dfbb91a7290c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2888,7 +2888,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ae4f49676ad04f02ac5baf0c9dcab743",
+       "model_id": "86a9dd10f493486ba7e0b560222baa22",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3044,7 +3044,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b52979cf0db4fdf80f3f0e26b3aca1b",
+       "model_id": "ba1cb3a240c945f9ba97b4b5271612ab",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3284,7 +3284,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "200fa84bcab9401fa3df35d3c95759b7",
+       "model_id": "0f159507aafc4f1db28117046b74aaee",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3312,7 +3312,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dcb1096e594e41c2a16e08abf3ff0e1c",
+       "model_id": "58815b1dc36a4e8e85f4f1745fa454aa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3500,7 +3500,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "edd895aaf02e425a8af395c6a43cde37",
+       "model_id": "35833ed4ad6d4e24a95100311633c2e5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -4080,8 +4080,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>11746</td>\n",
-       "      <td>6s9x</td>\n",
+       "      <td>2542</td>\n",
+       "      <td>4ejn</td>\n",
        "      <td>-</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
@@ -4089,22 +4089,19 @@
        "      <td>AKT1</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>KLLGKGTFGKVILYAMKIL_________QNSRPFLTALKYSCFVME...</td>\n",
-       "      <td>L1W</td>\n",
+       "      <td>KLLGKGTFGKVILYAMKIL_______VLQNSRPFLTALKYSCFVME...</td>\n",
        "      <td>-</td>\n",
+       "      <td>0R4</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>out</td>\n",
        "      <td>na</td>\n",
-       "      <td>2.6</td>\n",
-       "      <td>3.2</td>\n",
-       "      <td>9</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.959</td>\n",
-       "      <td>2.388</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
+       "      <td>2.19</td>\n",
+       "      <td>4.4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>22</td>\n",
+       "      <td>0.950</td>\n",
+       "      <td>2.319</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -4112,21 +4109,24 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>20.264299</td>\n",
-       "      <td>67.654297</td>\n",
-       "      <td>58.354900</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>18.979799</td>\n",
+       "      <td>65.341499</td>\n",
+       "      <td>56.192699</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2534</td>\n",
-       "      <td>3ocb</td>\n",
-       "      <td>-</td>\n",
+       "      <td>10881</td>\n",
+       "      <td>6npz</td>\n",
+       "      <td>A</td>\n",
        "      <td>B</td>\n",
        "      <td>Human</td>\n",
        "      <td>1</td>\n",
@@ -4134,23 +4134,18 @@
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...</td>\n",
-       "      <td>XM1</td>\n",
+       "      <td>-</td>\n",
        "      <td>-</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>in</td>\n",
        "      <td>in</td>\n",
-       "      <td>2.7</td>\n",
+       "      <td>2.12</td>\n",
        "      <td>8.0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.778</td>\n",
-       "      <td>2.095</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
+       "      <td>0.776</td>\n",
+       "      <td>2.092</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -4161,9 +4156,14 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>18.755400</td>\n",
-       "      <td>61.403500</td>\n",
-       "      <td>57.872101</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>17.940701</td>\n",
+       "      <td>60.261398</td>\n",
+       "      <td>66.135399</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -4211,7 +4211,7 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11708</th>\n",
+       "      <th>11776</th>\n",
        "      <td>9070</td>\n",
        "      <td>6bq1</td>\n",
        "      <td>-</td>\n",
@@ -4255,7 +4255,7 @@
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11709</th>\n",
+       "      <th>11777</th>\n",
        "      <td>9069</td>\n",
        "      <td>6bq1</td>\n",
        "      <td>-</td>\n",
@@ -4300,109 +4300,109 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>11710 rows × 41 columns</p>\n",
+       "<p>11778 rows × 41 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "       structure.klifs_id structure.pdb_id structure.alternate_model  \\\n",
-       "0                   11746             6s9x                         -   \n",
-       "1                    2534             3ocb                         -   \n",
+       "0                    2542             4ejn                         -   \n",
+       "1                   10881             6npz                         A   \n",
        "...                   ...              ...                       ...   \n",
-       "11708                9070             6bq1                         -   \n",
-       "11709                9069             6bq1                         -   \n",
+       "11776                9070             6bq1                         -   \n",
+       "11777                9069             6bq1                         -   \n",
        "\n",
        "      structure.chain species.klifs  kinase.klifs_id kinase.klifs_name  \\\n",
        "0                   A         Human                1              AKT1   \n",
        "1                   B         Human                1              AKT1   \n",
        "...               ...           ...              ...               ...   \n",
-       "11708               A         Human             1096             PI4KA   \n",
-       "11709               E         Human             1096             PI4KA   \n",
+       "11776               A         Human             1096             PI4KA   \n",
+       "11777               E         Human             1096             PI4KA   \n",
        "\n",
        "      kinase.family kinase.group  \\\n",
        "0              <NA>         <NA>   \n",
        "1              <NA>         <NA>   \n",
        "...             ...          ...   \n",
-       "11708          <NA>         <NA>   \n",
-       "11709          <NA>         <NA>   \n",
+       "11776          <NA>         <NA>   \n",
+       "11777          <NA>         <NA>   \n",
        "\n",
        "                                        structure.pocket ligand.expo_id  \\\n",
-       "0      KLLGKGTFGKVILYAMKIL_________QNSRPFLTALKYSCFVME...            L1W   \n",
-       "1      KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...            XM1   \n",
+       "0      KLLGKGTFGKVILYAMKIL_______VLQNSRPFLTALKYSCFVME...              -   \n",
+       "1      KLLGKGTFGKVILYAMKILHTLTENRVLQNSRPFLTALKYSCFVME...              -   \n",
        "...                                                  ...            ...   \n",
-       "11708  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
-       "11709  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
+       "11776  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
+       "11777  _PMQSAAKAPYLAAIFKVGDCRQDMLALQIIDLFVFPYRVVCGVIE...            E4S   \n",
        "\n",
        "      ligand_allosteric.expo_id ligand.name ligand_allosteric.name  \\\n",
-       "0                             -        <NA>                   <NA>   \n",
+       "0                           0R4        <NA>                   <NA>   \n",
        "1                             -        <NA>                   <NA>   \n",
        "...                         ...         ...                    ...   \n",
-       "11708                         -        <NA>                   <NA>   \n",
-       "11709                         -        <NA>                   <NA>   \n",
+       "11776                         -        <NA>                   <NA>   \n",
+       "11777                         -        <NA>                   <NA>   \n",
        "\n",
        "      structure.dfg structure.ac_helix  structure.resolution  \\\n",
-       "0               out                 na                   2.6   \n",
-       "1                in                 in                   2.7   \n",
+       "0               out                 na                  2.19   \n",
+       "1                in                 in                  2.12   \n",
        "...             ...                ...                   ...   \n",
-       "11708            in                 in                   NaN   \n",
-       "11709            in                 in                   NaN   \n",
+       "11776            in                 in                   NaN   \n",
+       "11777            in                 in                   NaN   \n",
        "\n",
        "       structure.qualityscore  structure.missing_residues  \\\n",
-       "0                         3.2                           9   \n",
+       "0                         4.4                           7   \n",
        "1                         8.0                           0   \n",
        "...                       ...                         ...   \n",
-       "11708                     6.8                           2   \n",
-       "11709                     6.8                           2   \n",
+       "11776                     6.8                           2   \n",
+       "11777                     6.8                           2   \n",
        "\n",
        "       structure.missing_atoms  structure.rmsd1  structure.rmsd2  \\\n",
-       "0                            0            0.959            2.388   \n",
-       "1                            0            0.778            2.095   \n",
+       "0                           22            0.950            2.319   \n",
+       "1                            0            0.776            2.092   \n",
        "...                        ...              ...              ...   \n",
-       "11708                        0            1.704            2.676   \n",
-       "11709                        0            1.699            2.670   \n",
+       "11776                        0            1.704            2.676   \n",
+       "11777                        0            1.699            2.670   \n",
        "\n",
        "       structure.front  structure.gate  structure.back  structure.fp_i  \\\n",
-       "0                False           False            True           False   \n",
-       "1                 True           False           False           False   \n",
+       "0                False           False           False           False   \n",
+       "1                False           False           False           False   \n",
        "...                ...             ...             ...             ...   \n",
-       "11708             True           False           False           False   \n",
-       "11709             True            True           False           False   \n",
+       "11776             True           False           False           False   \n",
+       "11777             True            True           False           False   \n",
        "\n",
        "       structure.fp_ii  structure.bp_i_a  structure.bp_i_b  \\\n",
        "0                False             False             False   \n",
-       "1                 True             False             False   \n",
+       "1                False             False             False   \n",
        "...                ...               ...               ...   \n",
-       "11708            False             False              True   \n",
-       "11709            False              True              True   \n",
+       "11776            False             False              True   \n",
+       "11777            False              True              True   \n",
        "\n",
        "       structure.bp_ii_in  structure.bp_ii_a_in  structure.bp_ii_b_in  \\\n",
        "0                   False                 False                 False   \n",
        "1                   False                 False                 False   \n",
        "...                   ...                   ...                   ...   \n",
-       "11708               False                 False                 False   \n",
-       "11709               False                 False                 False   \n",
+       "11776               False                 False                 False   \n",
+       "11777               False                 False                 False   \n",
        "\n",
        "       structure.bp_ii_out  structure.bp_ii_b  structure.bp_iii  \\\n",
-       "0                     True              False              True   \n",
+       "0                    False              False             False   \n",
        "1                    False              False             False   \n",
        "...                    ...                ...               ...   \n",
-       "11708                False              False             False   \n",
-       "11709                False              False             False   \n",
+       "11776                False              False             False   \n",
+       "11777                False              False             False   \n",
        "\n",
        "       structure.bp_iv  structure.bp_v  structure.grich_distance  \\\n",
-       "0                 True           False                 20.264299   \n",
-       "1                False           False                 18.755400   \n",
+       "0                False           False                 18.979799   \n",
+       "1                False           False                 17.940701   \n",
        "...                ...             ...                       ...   \n",
-       "11708            False           False                 18.324301   \n",
-       "11709            False           False                 18.168600   \n",
+       "11776            False           False                 18.324301   \n",
+       "11777            False           False                 18.168600   \n",
        "\n",
        "       structure.grich_angle  structure.grich_rotation structure.filepath  \n",
-       "0                  67.654297                 58.354900               <NA>  \n",
-       "1                  61.403500                 57.872101               <NA>  \n",
+       "0                  65.341499                 56.192699               <NA>  \n",
+       "1                  60.261398                 66.135399               <NA>  \n",
        "...                      ...                       ...                ...  \n",
-       "11708              58.963501                131.186996               <NA>  \n",
-       "11709              58.645401                136.503006               <NA>  \n",
+       "11776              58.963501                131.186996               <NA>  \n",
+       "11777              58.645401                136.503006               <NA>  \n",
        "\n",
-       "[11710 rows x 41 columns]"
+       "[11778 rows x 41 columns]"
       ]
      },
      "execution_count": 54,
@@ -5290,9 +5290,9 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>8735</td>\n",
+       "      <td>8733</td>\n",
        "      <td>5m5a</td>\n",
-       "      <td>A</td>\n",
+       "      <td>B</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>128</td>\n",
@@ -5334,9 +5334,9 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>8733</td>\n",
+       "      <td>8735</td>\n",
        "      <td>5m5a</td>\n",
-       "      <td>B</td>\n",
+       "      <td>A</td>\n",
        "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>128</td>\n",
@@ -5515,8 +5515,8 @@
       ],
       "text/plain": [
        "    structure.klifs_id structure.pdb_id structure.alternate_model  \\\n",
-       "0                 8735             5m5a                         A   \n",
-       "1                 8733             5m5a                         B   \n",
+       "0                 8733             5m5a                         B   \n",
+       "1                 8735             5m5a                         A   \n",
        "..                 ...              ...                       ...   \n",
        "12                3317             3eqf                         -   \n",
        "13                2991             1r0p                         -   \n",
@@ -7263,9 +7263,9 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>37</th>\n",
-       "      <td>5814</td>\n",
+       "      <td>5811</td>\n",
        "      <td>2y6o</td>\n",
-       "      <td>A</td>\n",
+       "      <td>B</td>\n",
        "      <td>A</td>\n",
        "      <td>Mouse</td>\n",
        "      <td>668</td>\n",
@@ -7283,8 +7283,8 @@
        "      <td>8.7</td>\n",
        "      <td>3</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.783</td>\n",
-       "      <td>2.116</td>\n",
+       "      <td>0.782</td>\n",
+       "      <td>2.117</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -7301,8 +7301,8 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>19.312901</td>\n",
-       "      <td>61.760502</td>\n",
-       "      <td>52.242401</td>\n",
+       "      <td>61.760201</td>\n",
+       "      <td>52.242699</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -7359,7 +7359,7 @@
        "0                 5018             3lfa                         -   \n",
        "1                 8339             5vcv                         -   \n",
        "..                 ...              ...                       ...   \n",
-       "37                5814             2y6o                         A   \n",
+       "37                5811             2y6o                         B   \n",
        "38                5774             2zva                         -   \n",
        "\n",
        "   structure.chain species.klifs  kinase.klifs_id kinase.klifs_name  \\\n",
@@ -7401,14 +7401,14 @@
        "0                            5                       15            0.765   \n",
        "1                            0                        0            0.775   \n",
        "..                         ...                      ...              ...   \n",
-       "37                           3                        1            0.783   \n",
+       "37                           3                        1            0.782   \n",
        "38                           0                        0            0.780   \n",
        "\n",
        "    structure.rmsd2  structure.front  structure.gate  structure.back  \\\n",
        "0             2.173             True            True            True   \n",
        "1             2.104             True            True           False   \n",
        "..              ...              ...             ...             ...   \n",
-       "37            2.116             True            True            True   \n",
+       "37            2.117             True            True            True   \n",
        "38            2.099             True            True            True   \n",
        "\n",
        "    structure.fp_i  structure.fp_ii  structure.bp_i_a  structure.bp_i_b  \\\n",
@@ -7436,14 +7436,14 @@
        "0            False                  0.000000               0.000000   \n",
        "1            False                 18.551800              59.874401   \n",
        "..             ...                       ...                    ...   \n",
-       "37           False                 19.312901              61.760502   \n",
+       "37           False                 19.312901              61.760201   \n",
        "38           False                 19.297100              62.362701   \n",
        "\n",
        "    structure.grich_rotation structure.filepath  \n",
        "0                   0.000000               <NA>  \n",
        "1                  54.618500               <NA>  \n",
        "..                       ...                ...  \n",
-       "37                 52.242401               <NA>  \n",
+       "37                 52.242699               <NA>  \n",
        "38                 53.872799               <NA>  \n",
        "\n",
        "[39 rows x 41 columns]"
@@ -7883,72 +7883,72 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>1047</td>\n",
-       "      <td>3qri</td>\n",
+       "      <td>1089</td>\n",
+       "      <td>2g2h</td>\n",
+       "      <td>-</td>\n",
        "      <td>B</td>\n",
-       "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>392</td>\n",
        "      <td>ABL1</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
-       "      <td>919</td>\n",
+       "      <td>P16</td>\n",
        "      <td>-</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>out</td>\n",
-       "      <td>out</td>\n",
-       "      <td>2.10</td>\n",
+       "      <td>out-like</td>\n",
+       "      <td>in</td>\n",
+       "      <td>2.00</td>\n",
        "      <td>8.0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.928</td>\n",
-       "      <td>2.279</td>\n",
+       "      <td>0.863</td>\n",
+       "      <td>2.140</td>\n",
        "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>True</td>\n",
-       "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>18.143700</td>\n",
-       "      <td>59.950401</td>\n",
-       "      <td>8.298940</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>16.691601</td>\n",
+       "      <td>55.077801</td>\n",
+       "      <td>1.634190</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>7526</td>\n",
-       "      <td>5mo4</td>\n",
+       "      <td>10944</td>\n",
+       "      <td>6npu</td>\n",
+       "      <td>-</td>\n",
        "      <td>B</td>\n",
-       "      <td>A</td>\n",
        "      <td>Human</td>\n",
        "      <td>392</td>\n",
        "      <td>ABL1</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIIIE...</td>\n",
-       "      <td>NIL</td>\n",
-       "      <td>AY7</td>\n",
+       "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
+       "      <td>STI</td>\n",
+       "      <td>KWV</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>out</td>\n",
        "      <td>out</td>\n",
-       "      <td>2.17</td>\n",
-       "      <td>8.0</td>\n",
+       "      <td>2.33</td>\n",
+       "      <td>8.5</td>\n",
+       "      <td>2</td>\n",
        "      <td>3</td>\n",
-       "      <td>8</td>\n",
-       "      <td>0.864</td>\n",
-       "      <td>2.218</td>\n",
+       "      <td>0.936</td>\n",
+       "      <td>2.305</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -7961,12 +7961,12 @@
        "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>True</td>\n",
-       "      <td>19.025999</td>\n",
-       "      <td>63.105900</td>\n",
-       "      <td>16.033001</td>\n",
+       "      <td>False</td>\n",
+       "      <td>18.220200</td>\n",
+       "      <td>61.682899</td>\n",
+       "      <td>20.631399</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -8015,10 +8015,10 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>203</th>\n",
-       "      <td>5702</td>\n",
-       "      <td>3mss</td>\n",
-       "      <td>-</td>\n",
-       "      <td>D</td>\n",
+       "      <td>5708</td>\n",
+       "      <td>3ms9</td>\n",
+       "      <td>B</td>\n",
+       "      <td>A</td>\n",
        "      <td>Mouse</td>\n",
        "      <td>532</td>\n",
        "      <td>ABL1</td>\n",
@@ -8026,17 +8026,17 @@
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
        "      <td>STI</td>\n",
-       "      <td>MS7</td>\n",
+       "      <td>MS9</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>out</td>\n",
        "      <td>out</td>\n",
-       "      <td>1.95</td>\n",
+       "      <td>1.80</td>\n",
        "      <td>7.6</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.921</td>\n",
-       "      <td>2.303</td>\n",
+       "      <td>0.923</td>\n",
+       "      <td>2.307</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -8052,15 +8052,15 @@
        "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>18.569700</td>\n",
-       "      <td>62.892899</td>\n",
-       "      <td>14.525800</td>\n",
+       "      <td>18.652599</td>\n",
+       "      <td>63.107601</td>\n",
+       "      <td>15.873000</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>204</th>\n",
-       "      <td>5709</td>\n",
-       "      <td>1opk</td>\n",
+       "      <td>5703</td>\n",
+       "      <td>1iep</td>\n",
        "      <td>-</td>\n",
        "      <td>A</td>\n",
        "      <td>Mouse</td>\n",
@@ -8069,18 +8069,18 @@
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...</td>\n",
-       "      <td>P16</td>\n",
+       "      <td>STI</td>\n",
        "      <td>-</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>out-like</td>\n",
-       "      <td>in</td>\n",
-       "      <td>1.80</td>\n",
-       "      <td>8.0</td>\n",
+       "      <td>out</td>\n",
+       "      <td>out</td>\n",
+       "      <td>2.10</td>\n",
+       "      <td>7.6</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.832</td>\n",
-       "      <td>2.131</td>\n",
+       "      <td>0.922</td>\n",
+       "      <td>2.306</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -8091,14 +8091,14 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>True</td>\n",
        "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>16.653601</td>\n",
-       "      <td>54.774502</td>\n",
-       "      <td>0.536291</td>\n",
+       "      <td>18.631001</td>\n",
+       "      <td>63.209400</td>\n",
+       "      <td>14.280100</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -8108,17 +8108,17 @@
       ],
       "text/plain": [
        "     structure.klifs_id structure.pdb_id structure.alternate_model  \\\n",
-       "0                  1047             3qri                         B   \n",
-       "1                  7526             5mo4                         B   \n",
+       "0                  1089             2g2h                         -   \n",
+       "1                 10944             6npu                         -   \n",
        "..                  ...              ...                       ...   \n",
-       "203                5702             3mss                         -   \n",
-       "204                5709             1opk                         -   \n",
+       "203                5708             3ms9                         B   \n",
+       "204                5703             1iep                         -   \n",
        "\n",
        "    structure.chain species.klifs  kinase.klifs_id kinase.klifs_name  \\\n",
-       "0                 A         Human              392              ABL1   \n",
-       "1                 A         Human              392              ABL1   \n",
+       "0                 B         Human              392              ABL1   \n",
+       "1                 B         Human              392              ABL1   \n",
        "..              ...           ...              ...               ...   \n",
-       "203               D         Mouse              532              ABL1   \n",
+       "203               A         Mouse              532              ABL1   \n",
        "204               A         Mouse              532              ABL1   \n",
        "\n",
        "    kinase.family kinase.group  \\\n",
@@ -8129,81 +8129,81 @@
        "204          <NA>         <NA>   \n",
        "\n",
        "                                      structure.pocket ligand.expo_id  \\\n",
-       "0    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            919   \n",
-       "1    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIIIE...            NIL   \n",
+       "0    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            P16   \n",
+       "1    HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            STI   \n",
        "..                                                 ...            ...   \n",
        "203  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            STI   \n",
-       "204  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            P16   \n",
+       "204  HKLGGGQYGEVYEVAVKTLEFLKEAAVMKEIKPNLVQLLGVYIITE...            STI   \n",
        "\n",
        "    ligand_allosteric.expo_id ligand.name ligand_allosteric.name  \\\n",
        "0                           -        <NA>                   <NA>   \n",
-       "1                         AY7        <NA>                   <NA>   \n",
+       "1                         KWV        <NA>                   <NA>   \n",
        "..                        ...         ...                    ...   \n",
-       "203                       MS7        <NA>                   <NA>   \n",
+       "203                       MS9        <NA>                   <NA>   \n",
        "204                         -        <NA>                   <NA>   \n",
        "\n",
        "    structure.dfg structure.ac_helix  structure.resolution  \\\n",
-       "0             out                out                  2.10   \n",
-       "1             out                out                  2.17   \n",
+       "0        out-like                 in                  2.00   \n",
+       "1             out                out                  2.33   \n",
        "..            ...                ...                   ...   \n",
-       "203           out                out                  1.95   \n",
-       "204      out-like                 in                  1.80   \n",
+       "203           out                out                  1.80   \n",
+       "204           out                out                  2.10   \n",
        "\n",
        "     structure.qualityscore  structure.missing_residues  \\\n",
        "0                       8.0                           0   \n",
-       "1                       8.0                           3   \n",
+       "1                       8.5                           2   \n",
        "..                      ...                         ...   \n",
        "203                     7.6                           0   \n",
-       "204                     8.0                           0   \n",
+       "204                     7.6                           0   \n",
        "\n",
        "     structure.missing_atoms  structure.rmsd1  structure.rmsd2  \\\n",
-       "0                          0            0.928            2.279   \n",
-       "1                          8            0.864            2.218   \n",
+       "0                          0            0.863            2.140   \n",
+       "1                          3            0.936            2.305   \n",
        "..                       ...              ...              ...   \n",
-       "203                        0            0.921            2.303   \n",
-       "204                        0            0.832            2.131   \n",
+       "203                        0            0.923            2.307   \n",
+       "204                        0            0.922            2.306   \n",
        "\n",
        "     structure.front  structure.gate  structure.back  structure.fp_i  \\\n",
-       "0               True            True            True           False   \n",
+       "0               True            True           False           False   \n",
        "1               True            True            True           False   \n",
        "..               ...             ...             ...             ...   \n",
        "203             True            True            True           False   \n",
        "204             True            True            True           False   \n",
        "\n",
        "     structure.fp_ii  structure.bp_i_a  structure.bp_i_b  structure.bp_ii_in  \\\n",
-       "0              False             False              True               False   \n",
+       "0              False              True              True               False   \n",
        "1              False              True              True               False   \n",
        "..               ...               ...               ...                 ...   \n",
        "203            False              True              True               False   \n",
        "204            False              True              True               False   \n",
        "\n",
        "     structure.bp_ii_a_in  structure.bp_ii_b_in  structure.bp_ii_out  \\\n",
-       "0                   False                 False                 True   \n",
+       "0                   False                 False                False   \n",
        "1                   False                 False                 True   \n",
        "..                    ...                   ...                  ...   \n",
        "203                 False                 False                 True   \n",
-       "204                 False                 False                False   \n",
+       "204                 False                 False                 True   \n",
        "\n",
        "     structure.bp_ii_b  structure.bp_iii  structure.bp_iv  structure.bp_v  \\\n",
-       "0                False              True            False            True   \n",
-       "1                False              True            False            True   \n",
+       "0                False             False            False           False   \n",
+       "1                False             False             True           False   \n",
        "..                 ...               ...              ...             ...   \n",
        "203              False             False             True           False   \n",
-       "204              False             False            False           False   \n",
+       "204              False             False             True           False   \n",
        "\n",
        "     structure.grich_distance  structure.grich_angle  \\\n",
-       "0                   18.143700              59.950401   \n",
-       "1                   19.025999              63.105900   \n",
+       "0                   16.691601              55.077801   \n",
+       "1                   18.220200              61.682899   \n",
        "..                        ...                    ...   \n",
-       "203                 18.569700              62.892899   \n",
-       "204                 16.653601              54.774502   \n",
+       "203                 18.652599              63.107601   \n",
+       "204                 18.631001              63.209400   \n",
        "\n",
        "     structure.grich_rotation structure.filepath  \n",
-       "0                    8.298940               <NA>  \n",
-       "1                   16.033001               <NA>  \n",
+       "0                    1.634190               <NA>  \n",
+       "1                   20.631399               <NA>  \n",
        "..                        ...                ...  \n",
-       "203                 14.525800               <NA>  \n",
-       "204                  0.536291               <NA>  \n",
+       "203                 15.873000               <NA>  \n",
+       "204                 14.280100               <NA>  \n",
        "\n",
        "[205 rows x 41 columns]"
       ]
@@ -8587,7 +8587,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b8f612fba65942df989b70f5a57e83b0",
+       "model_id": "2e7bcc40967744de9e3c1cfe773b1e4a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -8771,7 +8771,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "315b4d95a5ac4ca58b7cd34aa76cbfcc",
+       "model_id": "1fd679b6234e4f0bb6a403a0d003fc7e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -8801,7 +8801,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e69f49d4202e482fb06ace8e29424dc7",
+       "model_id": "4c55a36d9a014d1ab7bfc92894194a1e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -8970,7 +8970,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa7e28411a5f4b68b0fa1ed0b0d80dd2",
+       "model_id": "0ecc5ae8145d44178d4ca600835af96a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9037,7 +9037,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8dd6d58e8ebb46fbaaf65e48b56a20bc",
+       "model_id": "df2be59c034c40bda54c0653de5caa3b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9218,7 +9218,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "083f8918e5044805ae1ccecb4bfd5af2",
+       "model_id": "06bdeb0340fe48c2b24ab021e425236d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9285,7 +9285,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ebd339e7212b49ca8483c973301537e6",
+       "model_id": "12bb5c29c045425c90408ee542891942",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9459,7 +9459,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1d4ce85c2bba46baaccc774b021e1ad4",
+       "model_id": "2f078beafd064777b86af6f69a7489c0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -9678,18 +9678,18 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9788</th>\n",
-       "      <td>13041</td>\n",
-       "      <td>0000000000000010000001000000000000000000000000...</td>\n",
+       "      <th>9845</th>\n",
+       "      <td>13109</td>\n",
+       "      <td>0000000000000010000001000000100000010000000000...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9789</th>\n",
-       "      <td>13042</td>\n",
-       "      <td>0000000000000010000001000000000000000000000000...</td>\n",
+       "      <th>9846</th>\n",
+       "      <td>13110</td>\n",
+       "      <td>0000000000000010000001000000100000010000000000...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>9790 rows × 2 columns</p>\n",
+       "<p>9847 rows × 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -9697,10 +9697,10 @@
        "0                      1  0000000000000010000000000000000000000000000000...\n",
        "1                      3  0000000000000010000000000000000000000000000000...\n",
        "...                  ...                                                ...\n",
-       "9788               13041  0000000000000010000001000000000000000000000000...\n",
-       "9789               13042  0000000000000010000001000000000000000000000000...\n",
+       "9845               13109  0000000000000010000001000000100000010000000000...\n",
+       "9846               13110  0000000000000010000001000000100000010000000000...\n",
        "\n",
-       "[9790 rows x 2 columns]"
+       "[9847 rows x 2 columns]"
       ]
      },
      "execution_count": 87,
@@ -10568,12 +10568,121 @@
     }
    ],
    "source": [
-    "local.pockets.by_structure_klifs_id(12347)"
+    "local.pockets.by_structure_klifs_id(12347)\n",
+    "# Equals\n",
+    "local.pockets.by_structure_klifs_id(12347, extension=\"mol2\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 102,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>residue.klifs_id</th>\n",
+       "      <th>residue.id</th>\n",
+       "      <th>residue.klifs_region_id</th>\n",
+       "      <th>residue.klifs_region</th>\n",
+       "      <th>residue.klifs_color</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>461</td>\n",
+       "      <td>I.1</td>\n",
+       "      <td>I</td>\n",
+       "      <td>khaki</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>462</td>\n",
+       "      <td>I.2</td>\n",
+       "      <td>I</td>\n",
+       "      <td>khaki</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>84</td>\n",
+       "      <td>_</td>\n",
+       "      <td>a.l.84</td>\n",
+       "      <td>a.l</td>\n",
+       "      <td>cornflowerblue</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>84</th>\n",
+       "      <td>85</td>\n",
+       "      <td>_</td>\n",
+       "      <td>a.l.85</td>\n",
+       "      <td>a.l</td>\n",
+       "      <td>cornflowerblue</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>85 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    residue.klifs_id residue.id residue.klifs_region_id residue.klifs_region  \\\n",
+       "0                  1        461                     I.1                    I   \n",
+       "1                  2        462                     I.2                    I   \n",
+       "..               ...        ...                     ...                  ...   \n",
+       "83                84          _                  a.l.84                  a.l   \n",
+       "84                85          _                  a.l.85                  a.l   \n",
+       "\n",
+       "   residue.klifs_color  \n",
+       "0                khaki  \n",
+       "1                khaki  \n",
+       "..                 ...  \n",
+       "83      cornflowerblue  \n",
+       "84      cornflowerblue  \n",
+       "\n",
+       "[85 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 102,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# It is also possible to get pocket details from pdb files\n",
+    "local.pockets.by_structure_klifs_id(12347, extension=\"pdb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
@@ -10613,7 +10722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10636,7 +10745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -10782,7 +10891,7 @@
        "[3604 rows x 11 columns]"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10794,7 +10903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
@@ -10845,7 +10954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -10884,7 +10993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -10916,8 +11025,7 @@
      "output_type": "stream",
      "text": [
       "Pocket (pdb): Number of atoms: 1156\n",
-      "Ligand (mol2): Number of atoms: 49\n",
-      "Ligand (pdb): Number of atoms: 31\n"
+      "Ligand (mol2): Number of atoms: 49\n"
      ]
     },
     {
@@ -10931,6 +11039,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Ligand (pdb): Number of atoms: 31\n",
       "Water (mol2): Number of atoms: 3\n"
      ]
     }
@@ -10957,7 +11066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -10984,7 +11093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
@@ -10999,7 +11108,8 @@
      "output_type": "stream",
      "text": [
       "Complex (mol2): Number of atoms: 3604\n",
-      "Protein (mol2): Number of atoms: 3552\n"
+      "Protein (mol2): Number of atoms: 3552\n",
+      "Pocket (mol2): Number of atoms: 1156\n"
      ]
     },
     {
@@ -11013,7 +11123,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pocket (mol2): Number of atoms: 1156\n",
       "Pocket (pdb): Number of atoms: 1156\n",
       "Ligand (mol2): Number of atoms: 49\n"
      ]
@@ -11071,17 +11180,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvomK+y5uIKJkWmJp4laiP/NaSYleLaybNm6Ja3fQFnJJx9stqW4ZZiqaaWSmGGoQKiCmSYgoKjIMw7DNMDPP74+DI+4IszDM9/3qxWvmcHieZ0w+fs95znkOjzEGQgghjcW39AAIIcS6UYwSQkiTUIwSQkiTUIwSQkiTUIwSQkiTUIwSctv58ygrq3t94QI0GouOhlgJilFCbps5E6+9Vvf6n/9EcbFFR0OshNDSAyCkedFq8cMPGDMGAGprUVyMigpotVCpoNOhvBx6PZRKAFCrc6uqjpWVlTHGuK9KpVKv15eXl+t0unnz5vXt29fFxcWyH4eYAcUoIXdYswYvvoinngKAAwcwZ84D9xw+vOTXX2c96LuZmZmDBg363//+Z4IxkuaFYpSQO/j7Izoaa9YAgFgMHx+IxRAI4OoKPh9ubuDx4O4OAN27u3btGuPm5sbn87mvrq6uAoFALBaXlZUtWLDg66+/njZt2nPPPWfZT0RMjUc3gxIAaWlpS5cujYiIWLx4saXHYklPPoldu+DmhqFDUVqKQ4fQpk0jm1q7dq1EIuncuXN2drajo6NRh0maF5piIgBw6dKlw4cP5+TkWHogzYJQiI8/xsWLTWrkX//6V79+/S5evPjee+8ZaVykmaIYJQBQWloKwMvLy9IDsaTDhzF5MlxdASA0FMeOwcenMe0cOHBAr9cLhUKZTMbn8+Pj48+dO2fcoZJmhWKUAIBcLgfg6elp6YFYjE6HuXPxxhvYu7duy+DBcHB47HZmzpw5evRomUwGIDQ09LXXXtNoNLNnz6azZy0YxSgBblWjthyjn3+Oc+fQoQMiI5vUDjehtHDhwqKiIgBr165t1arV0aNHv/jiC6OMkzRDFKMEuFWN2uxBfU0NVq4EgPfeg719k5qaOHHiuHHjysvL3377bQBubm7r1q0DsHnzcbncCEMlzRDFKAFsvhpdvx6FhejbF5MnA4Be36TWNmzY4OLisn379h9++AHAtGnTYmJO/vHHlnfeMcZYSfNDMUoA265Gy8oQHw8Aa9eCz4dOh9BQSCSorGxkg4GBgcuXLwcwb9686mo1gAULQoVCfP45Dh821qhJM0IxSgDbnqmXSlFaimHD8MwzAJCYiD/+wI4dsLNrfJvz5s0bMeJlb+/UNWscAHTujEWLwBj++U+o1UYaN2k26PJ7AgCenp4KhUIul9vacX1REbp0QXU10tIQFoaaGnTrhsuX8fXXmDq1SS2npyMsDEIhTp1Cz57QaNCvH86dw5o1sO1bHFogqkYJdDqdUqnk8/nu3E2OtmTLlhNCIXvhBYSFAcCGDbh8GX36YMqUprY8cCBiYqDRYPZsMAZ7e2zZAh4Pq1cjL6/pAyfNCFWjBHK53Nvb28vLq6SkxNJjMasLFy706tXLw6PzsWMZXbs6l5Whc2fI5ThwAM8+a4T2y8vRoweKivDZZ5gxAwBeeQWJiXjmGRw8aIT2STNB1Six3WvvFy9erNVqJ058smtXZwBbt/5dVobhw42ToQBcXfH++wAwfz5u3gSADz6Ajw9++gnffmucLkhzQDFKbHSaPj09/fvvv3dycnr33XcBXLt2bcWKoI4dJ65bV23EXqZOxbPPwsGh7kDeywtSKZydUV5uxE6IhVGMEhu9aHTRokWMsXnz5rVp0wbAihUrqqqq+vQRhIQ4Gbejzz7DuXN1514BzJiBtDT88gtKSwFAocDy5cbtkJgbxSixxWr04MGDhw4dcnd3X7BgAYC//vrrs88+EwgEq1atMnpfAQFwc7v9lseDmxtSUrBwIQBUV+PIEaP3ScyKYpTY3EWjjDFuWdXFixdzNfiSJUtqa2ujo6N79OhhnjGEhqKoCGlp5umNmBbFKLG5g/rt27dnZmYGBATMnTsXQEZGxnfffefo6MidJDWbjz7CvHnQas3ZJzEJeogIsbmZ+n379gGIi4sTiUQAqquru3XrNnbs2LZt25pzGF26YPRobN5szj6JSVCMEps7N+rj4wOgoqKCezt06NDs7GyNJZ5Jv2gRQkLg62v+nokx0UE9sbmD+lGjRgFYvnz5lStXuC1CoZCrTM2Dx0PnzgDg5IT330fXrmbrmZgExSixuWp01KhRkyZNUqlU8+bNM3/v1dUYMQIODqipAYDRoyGTmX8UxJgoRm2aWq3eunVrXl6el5eX7VSjADZs2ODu7v79998nJyebuev163HxIlJSmro+NGk+KEZtlEqlio+PDwwMnDVrllKp3LRpU4cOHSw9KPPx9/dfuXIlgDfeeMNwktQMysqwdi0ArFsHPv3ytRiM2BilUimVSg21Z79+/ZKSkvR6vaXHZW46nS4sLAzA/PnzzdbpO+8wgA0bZrYOiTnQCk82pKSkZOPGjR9//HFZWRmA8PBwiUQyduxYS4/LYrKysoKDgwH8/vvv/fv3N3V3d61tSloOS+c4MYcbN25IJBLDZHR4ePjPP/9s6UE1C9ws08CBA3U6nan7eu01BrCoKFP3Q8yNqtEWrqCg4MMPP/zPf/5TXV3N4/HGjBmzdOnSQYMGWXpczYVKperZs+eVK1c2b948e/Zs03V04QJ69QJjyM6Gue44JeZi6RwnppKXlxcbG+vg4ACAz+dHRkZmZGRYelDN0c6dOwG4urpevXrVdL08/zwD2KxZpuuBWAzFaAuUk5Mzffp0oVDIBWhUVFRubq6lB9WsjRs3DsDUqVNN1P7Jkyd79ZoxaJDclEFNLIZitEU5ffr09OnTBQIBAHt7++nTp1+4cMHSg7ICBQUFLi4uAH744QdTtP/000/j1gqnpOWhGG0hTpw4MXr0aO5EjZOTU2xsbGFhoaUHZU3Wrl0LoHPnzlVVVcZt+ccffwTg4eEhl8uN2zJpJmiKqSUoLi5euXLlpk2bXFxcoqOjJRJJQECApQdlZbRa7cCBA0+fPr106dK7Fm/ev3//lStXdDpdeXm5Xq9XKpWMMe6iMYVCAUCpVOr1+vLycp1Op1KpMjMznZ2duZ9ljIWEhGRmZq5bt27+/Pnm/1zEHCwc48QYEhMTAfTr14/qnaY4efIkn8+3t7c/e/Zs/e2Pe0lpSUmJ4We//vprAK1bt66srDT7ByJmQgvltQTc2iLDhw+3qfvijS40NHTmzJkymWz27NlHjhzh8Xjc9rFjxw4cOJDP57u5ufF4PHd3dwAeHh4A3Nzc+Hy+q6urQCAQi8VCodDFxYXbAUBtbe2yZcsArFy50pwrSBEzoxhtCWxtpTvTiY+P37t3b2pqamJi4iuvvMJtXLFiReNa27p168WLF7t16/bSSy8ZbYik+aEYbQlsbaU703Fzc1u3bt20adPmz58/ZswYboHn+zKcCdVqtRUVFbW1tZWVlRqNpqqqSq1W19TUlJWVLV++HIBUKuUuPiMtFf3fbQmoGjWiF198cdu2bSkpKSEhIZ07d37QhFJDmurfv/+AAQPGjx9v2hETS6MYbQmoGjWuSZMmpaWlXb58+fLlyw/ax3Am1M7OztnZ2d7eXiQSOTg4ODo6Ojk5OTg4iESisLCwGTNmmHPkxCIoRlsCW3tCsknpdLr169dXVlbOnTt34sSJ9SeU3N3deTweN6Fk6WGSZoRitCWwtUd7mtSXX3559uzZ9u3bf/DBB9yKBIQ8HC3A3RJQNWosGo2GWxV/1apVlKGkgagatXqM1f76q79W25W7K5w0xcaNG/Pz84OCgl588UVLj4VYDYpRq6fVyhn7y9HRz3C5OGkc7vlUAKRSKZ+elEQajP6uWD2tVg5AIKAj+qaKj48vLi4eOnToc889Z+mxEGtCMWr1dLpSAEIhzS81SXFx8fr16wFIpVJLj4VYGYpRq8dVo0IhVaNNsnz5cpVKNWHChCFDhlh6LMTKUIxaPa22FIBAQNVo4+Xn5//3v/8VCASrV6+29FiI9aEYtXo6HVWjTbVo0SKNRvPyyy/36tXL0mMh1odi1Opx1SidG220M2fO7Nixw9HRMS4uztJjIVaJLniyHK0W+/ahoAC9eiEiognNcDFK1WgjvfPOO3q9/vXXXw8MDLT0WIhVooeIWIhOh2efxRNPICQE+/ZBp4NEgv374eaGl19+rJZKSj5VqQ55e88Wi4eZaLAt2JEjR4YPH+7m5paXl0e3gZHGoWrUQvbuRbt2WL4cACIjMXgw1GrMmIHHvOq7puZcefnPWu3NiopfKUYfF2Ns4cKFACQSCWUoaTSKUQs5exbBwbffhoQgJwdDh8LLC56ed3z19KwYE6D3dhYIvIRCT6HQWyBwM/xcQUFMmzbrRKJgjeaBS7o9Wm0t8vPh7w9X1yZ8JOuzc+fOEydOtGrVKjY21tJjIVaMYtRCxGJUVNx+W1EBxqBQQKG4d9+rg/tUKLIMb3k8ARep3t4xPJ6guvqss3Oog0MntfpiVdUfQqH3rcD15PMbcJf9Dz8gLg5hYfjzT/TqhQ8/xN9/A0CHDmjRa7brdDruQUlxcXGGB3kS0gh0btRCcnLw2ms4ehT29lAoMHgwTpyAXg+5HKWldV9vvbgyV1styNfpSrXaEq22VKdTcm0EBKzy9JxSVLSsqiqzVatlOp3q8uV/1u+Ex3MQCj0dBO27zbG7o8jl/vP0RI8eGDoUJ07AwwMAoqLwj39AowGAyEg4Od137Evy86+p1Y58PoAVHTr42NmZ8k/KVLZu3Tpr1qwuXbqcPXvWzjo/AmkmWnK50az17o0ZM/Dkk+jYEXl5+OgjcI+TvN+aoW3ufMuYVqcr1WrlAoGnnZ1fhw7faLU3c3P7tmv3iYdHlFYr576r1Zbq9ZW1tdcEOicc/fv+w/j2W/ToUZehAMaPx/HjeNTdkBq9fmG7dl0fELJWobq6mnsY/Zo1ayhDSRNRjFrOrFmIiYFCcd/ofAgeTygU+gqFvgCqqjKcnPozpuHx7Fxdn3Nzm1B/T8bUWq1cX6nAryW3y9uSeq9dXFB/IXc7u7pS9FFyKioUtbUigSDIeg6HlUrlxYsX8/Ly8vLykpOTr1y5MmDAgEmTJll6XMTqUYxaFI/3uBl6F6Xyh6KiZYCgffvPeDz7e5p3sLMLgHsAHjSHX1aGt95CbS24iuzYMYSFNaTfv2tqlDqdl1DYPGNUoVD8fT/19/Hy8ho0aBCtLkiajs6NWrfKyvQrV+aLxU8GBKxqZBMJCUhJQVQUzp7FmTPYv/+RM0sL8vJmBgQ0h4N6rVZbWFiYl5dnKDM5lZWV9+4sEok63VJdXf3JJ5/4+/v//fffTs3ggxCrRtWoddNoCioqjtrZPfBx6o/25pt49lmcOoUxYyCVwhoe1paRkfHuu+/m5eVdunSptrb23h28vLw63alz586tWrWqv096enp6evpnn302d+5ccw2ctExUjVq3mzdlly/P9vaOaddOZrZOfykr6+vi4mWhy6FOnDixbNmylJQU7q2Hh0fHenr27Nm7d2/ucZ4Pt2vXrueff75t27YXL160t7/7fAghDUfVqHWzyJrNA1xcRp4509bR8XtLrIf022+/paSkPPfcc2vXru3UqZOjo+PD91coFPWP91944QVucfsJEyYEBQVlZ2d/+eWXr776qlnGTlomilHrZpF1SZRaLQMsNTWTnZ0NYNy4cfcuateQmSV/f38uRnk83qJFi1588cV///vfL7/8srBF32tATIr+6li3Ww9iMms1qtRqAbhZ6CwqF6NBQUHc24yMjDVr1nCVZlVV1b37Ozs71z9DOnjwYMO3Jk+evGLFivPnz3/77bfTpk0zz/hJy0Mxat1uHdSbtxrV6QC4WaJ802q1ubm5PB6vd+/e3Ba1Wr17927u9V3nSTnt27d/0GM+BQKBRCKJjo5es2bN1KlT6WmgpHEoRq1baWk3YLBO1+bRuxoPV426WiJGL1y4UFNT07FjR9dbq6j06dMnKSmJKzbd3Nwe/uP3+sc//rFq1apz587t2rXrhRdeMPZ4iU2gf36t2yuvxIeGpt24EfzoXY2n7qDeEjGalZUFoE+fPoYtYrE4KipqwIABjchQAHZ2dgsWLACwevVqumqFNA7FqHWTy4H734hvQnUH9ZY4N8qdGK0fo00XHR3dunXr06dP79+/34jNEttBMWrduHX1zByj5ZauRg3zS0bh4ODw9ttvA+AWKyHkcVGMWjGVChoNxGKY+eJxC54bFQrn9O8/Pyion3GbnTVrlq+v78mTJw8dOmTcloktoBi1YhY5ogegPXq0S26ua1mZmftVKrFnz+g//1zXuXNn47YsEonefPNNAGvWrDFuy8QWUIxasdJSADD/M4QOrV+//aWX7O+3UL9JZWWBMfTubZL7/ufOnevh4XH48OFjx44Zv3XSolGMWjFLVaNyuRyA+Z8Bl5UFAEadXrrN1dWVeyLTe++9Z5IOSMtFMWodLl6EXl/3urAQlZX44w8EB+PIEaxejbNnzTqY0tJSAJ5mz+/sbAAw6vTSHWJjY8Vi8Y8//pienm6qPkhLRDFqHSZNgkpV93rBAmRmIiQEO3bgyScREoKoKPONRKPRVFRU2NnZubg04Hl5RsVVo6aLUU9Pzzlz5oAKUvKYKEatVe/e+M9/cOOGufs1HNGbed14xuqKbtPFKIB//etfIpFoz5493JVVhDQExajV2LQJH36IDz/E+fMA4OCApUsxf765h8Ed0Zv/xGh+PsrLERAAnyYsUX0vvV4fGxt78OBB7q2vr+/MmTMZY8uWLdPpdMbsibRcFKNWo3t39OyJnj1huOlxwgQoFDhyxKzD4KpR858YNcX8kk6ni46O3rBhw7Rp01S3TpqMHz/ezs4uLS3Nz89v8uTJW7duvXbtmjF7JS0OxajVGDECo0Zh1Cj4+9/e+PHHWLwYAE6exKefwgw3hVuqGpXLIRbj1rpORqDVal955ZXExERnZ+ft27eLxWIAGRkZkyZNqq2tra2tlcvlO3bsmDVrVtu2bYcMGbJ69erMzEy6757cByPWoG9fVlZW93rKFHb0KAsOrnu7fDnr3p1168YANno0u3LFhMPIzMwMDw93d3fv0KHD1atXTdhTPbt3s6NHGWNMr2c7drCiIiO0qVarJ06cCMDNze23337jNh47doxb3yQyMrK6uvrChQsfffTRyJEjHRwcDL8v/v7+b7+9eceO2/87CKEYtQ7p6UyrrXt99iwrK2MnT9a9ra5maWksKYl5ezOAubkxmcz4Azh8+HBERAQXJc7OzgA8PDy++uor4/d0j8mTWceOTKFgjLFp025/8EarrKx85plnuI9w8lZzv/76K1eQTpkyRaPR1N+/qqoqJSUlNjY2MDAQwLBhhwEmELDgYBYXxzIymF5/e+erV1lhYd3roiImlzd1tKT5oxhtOa5fZxMmMIAB7LnnmLGKxdTU1BEjRnABKhaLY2Njs7Kyxo8fz20ZM2aMqcvSyZPZkiVszhzGjBGjFRUV3Mfx8/M7c+YMt3H//v3cY5anTZtWW1v7kB/PysrasEE+bBgTCuv+qAHWrh2bPZslJ7PKSrZ0KQsMZCoVY4wtX87M8g8NsTCK0ZYmKYl5ejKA+fiw775rfDt6vT45OXnQoEFcXHp5ecXFxZWWltbrKMnDwwOAj4/Pd03p6VEmT2bZ2eypp9jJk02NUYVCwT1EpFWrVjk5OdzG5ORk7rB91qxZOp2uwU2xpCT2yivMz+92njo5sbffZhMnsvnzGaMYtRkUoy1QQQGLiKj7xZ49u1z+mAeWOp0uOTk5OLhuKWgfH5+4uLiy+50LLCgoMBzpR0VFlZSUGOkTMMaYXs927WLfflsXozk5bMgQNnUqO3mSffMNu/Owu0FKS0tDQ0MBtGvX7uLFi9zGb775xs7ODsD8+fP19Q/OH0dODpNKWUQECw5mS5eynTtZeDg7c4Zi1FZQjLZMej2TyZirK+vbN9bPz2/37t0N+SmdTpeUlNS9e3cuGdu2bZuQkFBVVWXY4fTp0zdv3ryzI71MJuPuaPL399+zZ0/TB6/TseRkNmAAA1irVuyFF1h2NmOMLVjAPDxYfDwDWGAgk8luny9+pOvXr3OrlHbt2rXw1snLL7/8UiAQAJBIJE0fNmNMrWZLl7Lvv2d//MGefJJi1FZQjLZkeXmlTzzxBJeJr776qlKpfNCearU6MTGxS5cu3M7t27dPSEiorq427HDq1KmoqCgej7dw4cJ7f/zvv/8eNmyYoSytf+z/WDQa9vnnrGvXulI6MJBt3Mhefpnl5jLGmErFundnmzezHj3qdujfnx048OhmL1++zH20Hj16GM7kbt68mXuG3YoVKxo32vviYpQx9vrrLCiIYtQmUIy2cFy1KBKJAAQGBv7888937VBTUyOTydq0qXsoXqdOnWQyWf1plqNHj3Lz2twc/bvvvvvIjtq1a3fo0KHHGqdazRITWefOdfnYoQNLSGD1YvwOOh1LSmIdOtTtPGQIS019YMv5+fmdOnUC0L9/f0MpvXbtWgA8Hu+jjz56rHE+kiFGlUoWEEAxahMoRm1Cbm7uwIEDueCIiYlRqVSMMZVKlZCQ0KpVKy4ig4KCEhMTtfWOk1NTUyMjI7nvuri4xMbGFj3qos2zZ8/e29HDVVZWbt2aGhBQl4k9e7KvvmrQ0bpazWQy5utb94MRESwr6z67paamikSiwYMHK7hrphiTSqXcCDdu3Pjobh7T1at112YVFrJPP6ULnmwCxaitqK2tXbVqlb29PYCOHTu++uqrhhs6Bw0alJycXH+CJSUlJSwsjPuuq6urRCJp+DxVbW2tVCrlOurQocORI0cetKchxwUC+/btNX36sMTExzjdeasRJpUysZgB7KmnDkZFReXn59+1z/Hjxw2BvnTpUgACgWDbtm2P19PjqK5mDg6Mz2eNPb1BrAnFqG3Jzs4eMGCA4RL68PDw5ORkw3e5OfqQkJBHztE/UlZWVv/+/QHw+fzY2Niampr635XL5XFxcdz1UgDCwsIOHsxp7Dw5Y4xdvcreeEMjFvsBEIlECxcuNNSeBnq9ft68eQDs7e137NjR+M4a5oknGMD27jV1P8TyKEZtjlqt5u6IT0pKMmzk5uh79OjB5Zqfn59UKq2srGxKRxqNRiqVcpcT9ezZMz09nTFWXFwcFxfn7u7OdXRXjjfR+fPnuXkw7g4lqVRquMxAq9VGR0cDcHBw2LVrl7F6fIglSxhQdwEpadkoRm0RV4oajnMVCkXHjh25XOvQocOWLVvuKh6b4vjx4926dQNgZ2cXHh7OzUEBGDVq1LFjx4zVS32///674bar1q1by2Sympqal156iStUf/rpJ1N0yklPZ//+d939Yz/9xAAWEmK63khzQTFqc9RqNXdgW3/js88+27Fjx7vm6I2lurpaIpHweLzWrVvzeLzIyMiTTb8x/lEOHjzInb4AwC044urqmvqQGX1jGDuWASwxkTHGKiuZvT0TCGgRk5aPYtTmFBUVcXdD1t9YXFzc8PsgGyc8PByAKSbHH0Sv1yclJXXq1KlNmzZisfj48eOm7vH99xnAoqPr3g4ezAC2f7+puyUWRuuN2pz7rrvs4+PDXYtuOlqtFoDhHlMz4PF4UVFRp0+fLikpqaioMPrT7e81fDiA2wtpc3ckmHldbWJ+FKM2x2zrLufm5u7cufM898wTyz1P1MXFJSwsjDFmhgfQ9+sHd3fk5aGwEKAYtRkUozbHbE8B2bNnz6RJkxITE+v3a/5l8wFwN6oeMX2eCQQYMgQAUlMBIDwc9vZQKmsqKqpN3TWxIIpRm2O2OKtffur1+rKyMj6fb7jUyZzMFqMAhg0Dn4/MTBUAsRhDhow/d84pLS3VDF0TS6EYtTlmO7iuX/aWlZXp9Xp3d3duRSUzGzx4sKOj45kzZ8rKykzd19NP54nF7fftG8i9DQnpCuDo0aOm7pdYEMWozTHbudH6Za+lnifKcXR0DAkJ0ev1Zjk92k6vLz1//jx3RQRXCP/666+m7pdYEMWozTFbotUvey14YpQzfPhwmOW4XigUcgvsc5E9dOhQgUCQnp5eVVVl6q6JpVCM2hyLVKOWmqY3MGdVWP9UrJubW9++fTUazYkTJ8zQNbEIilGbY+ZqtP5BvQWr0SFDhtjb2586dUqpVJq6r7tmtMw5wUUsgmLU5pgt0RQKBQBuGSeLV6MikSg4OFin06WlpZm6r4EDBzo7O+fm5hYXF4Ni1AZQjNoc8yRaeXm5RqMRi8XcwqNmO5PwEGaLM3t7+/fee2/79u3cEjBDhw7l8/knTpyoqakxddfEIihGbY55YvSu3LTsTD3HnFVhbGzs5MmTuRj19PQMCAjQ6XTjxo3btm3bjRs3zDAAYk5CSw+AmFVlZWVNTY1IJHJycjJpR3flZnOoRp944gmhUJiRkaFSqcRisXk6ZYy9+eabV65ccXV1TUlJSUlJAdCzZ8+xY8dGREQMHz5cKKTfQatH1ahtMfO1982qGnVxcenfv79WqzXbpDlj7I033li/fr29vX18fPymTZvGjBkjEolyc3Pj4+NHjhwZEBAwffr0b77ZXlpqnhERk6AYtS0WuRPUnP0+nDmP63U63YwZMzZt2iQSifbu3Tt79uw5c+bs27dPLpenpKRIJJIePXrcvHnzq6++Wr78e19fhIRg4UIcOwbGzDA6YkwUo7blvgfX3ISycd2VmxafqeeYLUY1Gs3//d//JSYmOjs779271/CEagCOjo4RERFSqTQ3N/fPP//88MMPhw+fKxTijz8QH4+hQ9GmDWbOxPffQ6UCgF9+QUhI3eujR7FiBd58E2fO1LW2fj127TL1pyGPQDFqW+49uL506VKXLl1mzZpVUVFhxI6aZzXK3VP0+++/m/SeIrVaPWXKlO+++87d3T0lJeXpp59+0J7dunV76623ZLJhJSXYtQszZ6JNGxQV4dNP8cIL8PbGiBHIzoZKhbg4AKiqglyO68dkHSIAAAcBSURBVNdhmPMvLUV5uek+CmkQilHbwqUb99A3TlpaWnV19datWwcMGGDEayqHDh26ZMkSrvrTarUqlUooFLq6uhqr/ca57z1FhYWFYWFhK1euzMjI0Ov1Teyiqqpq7Nixu3fv9vT0/Omnn7gbQx/JxQUTJmDrVhQWIi8PCQmIiABj+OUXiESYMAGnTuHUqdv7X7uG/Hzk58P0a62QBrDw6vvEvM6fPz9q1CiBQCCRSDQaDbcxOzvb8DDkmJiYJj4Q9F7cJT6+vr7GbbZx3nrrLQDLli0zbNmyZYvh18Hb2zsqKioxMbG0UQ+YV6lUTz31FAA/P7+srKwmDrW0lCUns+RkJpGw06dZeDjbv5+98QabMoVNmMBiYlhMDAsOZtu2NbEf0lQUozYnNjaWq0ZDQ0Nzc3O5jfd9GLKx5ObmAujevbsR22y03bt3Axg2bJhhS1VVFTfnwz3BlCMQCIKDg+Pi4rgStSEtKxSKsLAwAG3btr1w4YKxBszFKGPszTfZ1Kl1MXriRN134+IoRi2PYtQWpaamdurUCYCjo6NUKtVqtdz2kydPdu/eHYBQKJRIJGq12ijdffDBBwC6du1q6qfmNYRcLufz+XZ2dkePHr13PHl5eQkJCREREdzNVxw/P7/p06cnJSUplcoHNXvjxo2+ffsCaN++/cWLF404YEOMKpWsdev7x+i337ING5jxnopNHg/FqI1SKpUxMTFcWTp48ODz589z27mHIXOLKwcFBWVmZja6C71en5ycHBoailt31g8ZMsSIZVqjLVmyJDAwEICXl1dUVJRMJrt27dpd+yiVyu+++y46OrpVq1aGPHVwcBg5cuSVK1fu2vnatWu9e/cG0K1bt8LCQuOONjf39rNFf/6Z7dnDtm1jly7VbfnxR3bwIDt+nO3dy/77X+P2TBqKYtSmHThwoE2bNgCcnJykUqmhOvvtt9+6dOkCwM7OLi4uzlCuNpBWq/3mm2+CgoK49PH394+Ojvbz8wPg4uKyefPmBh4mm4hOp3v99dc7duxY/xA+PDx8zZo1mZmZ944tJydHKpVGRETY2dmJxeK7ivSCggLuz6pnz55FRUVm/Bx3+PRT9ssvlurc1lGM2jqFQhETE8OlSUREREFBAbe9srJSIpFwT10eNGjQuXPnGtKaRqNJTEzkzgwACAwMTEhIqKqququjkSNHXr582YSfqmHy8vJkMllkZKSDg4MhUn19fblDeIVCcdf+JSUlR44cqb8lPz+fi+MBAwbcvHnTjGO/w4ED7JNPLNU5oRgljDHG9u3bxx29urq6ymQyw/aDBw9y5apIJNq3b99DWlCr1YmJiVxdxp0iTEhIqK6uvmu3HTt2+Pj43NuRZVVWVqakpMTGxrZt2/auElUqlT5oluncuXOtW7cGEB4eXlZWZv5hc86cYc88wyQS9uOPlhqCraMYJXVu3Ljx/PPPcwkyatQowxlA7iyqt7f39evX7/uDNTU1MpmMS1sAnTp1kslktbW1D+ro+vXr48eP53YeO3bstQc0ayn3nWVq3759TExMUlJSeXk5t1tOTg73D8+wYcMMG4ltohgld0hKSuLuNXJ3d69fLd43Q1UqVUJCgmESJigoKDExsYEnUpOSkjw9PT0CAp4/fXqn5Q6HH6K0tHT79u0vvfSSr6+vIU+dnJxGjRr1zjvvcDdojR49mjtlQWwZxSi527Vr18aNG8elxqRJk+57yk+pVEqlUsO9nv37909KSnrciaPCwsJ3U1ODMzKCMzIW5uWVPbiAtTjDLBO3rh2fz7e3t3/++eeNdU0YsWo8RuvJkPv54osvXn/9dZVK5evru2XLlokTJ3Lbb968uWnTpo8//ph75nt4eLhEIhk7dmyjO/pBLo8vLKzS6TyFwkXt2j3l7m6cD2AaxcXFBw4c+OuvvyIjI4ODg2m1UAKAYpQ8UEFBQXR09C+//AIgKipq1apVn3/++YYNG7h1PcLDw1esWDFixIimd3RNo1lx6VKGSgUgwsNjcWCgK8UTsR4Uo+Rh9Hr9xo0bFy1aVFVV5ejoWFNTw+Pxxo0bt3Tp0pCQECN2xIBdJSUfFRZW6/XednZL2rXrIRJdVqu577ZzcPCyszNid4QYEcUoebQLFy7MmzevR48e165dW7x4seG6eqMrqKlZfulSdmUlDxjv41OsVge5uAAY6ubWXSQyUaeENBHFKGle9MC3xcV75fJILy8w9qKfn6VHRMgjUIyS5kjH2M6Skp8VCq4InRMQ4MintXFJM0Un8klzJODxAPQSiUZ7egKwr7fONCHNDcUoab587Oy60ilR0uzRgRIhhDQJnRslzZRSq2WAO11ASpo9ilFCCGkSOqgnhJAmoRglhJAmoRglhJAmoRglhJAmoRglhJAm+X8U1V9jMIYuMgAAAjB6VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHu/b+09BiDgAWJGBgiQB2IlIG5gZEvQANLMLGwJFiCakQUhAKUVDJBoJgSNrg7TIFwmYlGBoRRdhlNBAeR+KMWuABFmZodoQNAQCSYMCQ4FkH//M8JoAQWQOCsLNwNHAoNgBhODuAIjUwYTo3gCE3MCE68CM2cGE7NEAgsrAysbA5scAztHBhO7cAK7mAKHCAMnVwKneAIXdwYTN08Cj0QGE4+kAi9fBhOvQAKfVAK/VAYTv3SCgHQGk6BQgqAog5BwBpOYHIOMHIOsHIMICysjEzOnOBu7sJAgAwcbFzePBDMnG58Uv7QArzgsghjkG6S793eYX9gP4nhwstvf/c1gD2Jz32FwaM81BbNzt2s5RKqpgNXYzvI/MLt0ogOI/bYn7MAqbWcw+3PFtAMeAZJgNkNq9oEfqjvA6tkZRA+k3/MAs6N+nLIXFbsOZvO++2Hfd8DjAIituDbCYW5JMpht+KXPQfOzApi9RU3PIYyBCWI+T7tDjyQrmM0c1+KgsHQqmB3255u9WE8wmP2QYeb+wNvuYL2ZT5UObN5WCGZvCC860HHJGswO5+U7cFreDOyvzaU2ttX7a8Hii7PnHnDbLQF226GdbXYdjJVg9pGyZgfv6nYw245/r4PFcog5HpvmOjTsiwTbe+WEhkOrxBQwm0s15IBmhRfYfMFLJw9cZ2sEs70/zTzwxikNzBYDAFHjlN45N0kPAAACMnpUWHRNT0wgcmRraXQgMjAyMC4wOS4xAAB4nJ1WS27cMAzd+xS6wAgkRVHissj0AxRJgBToHbrqprl/qc/IHiQBYg4MDJ9pPvMvy+vr3/hlC+33cv35519YP7puW0gYEocA716qGn4TADT7C0aoUockJKVxQDQthIfwEcXx2oZFppKnBKn6WCgCNr+bbYHq9IWiSGksF4jCSC6WS4rEIw6OmbN4WVKmHlGKwJp9LGzZoDRiS5qdLClKqTAqbaH5snsxD6jiyG6p7MtLwJhrLrPrKrCXRZnriA2TOLvOalR7fY0lZwYfC0eWkkaGMrJ7AgohzllImLy+EMHsFyjqnCNuOc1DkiL+GpHKzDNkH4t1CWpOs9JEvuy2yvCNpRRnvzTbKjL4NLF7jgh1Tk9BPObl25m9CywwvFK567rPs9h+UdS5MbPKcaafzvhCkuZm0ELFx2JdB5VGzcGWhI8lR4WxpVqNCL2+KPWNab3LcwOfZ7HzKPXN0OZo8p1maSfJ2ipFQQ8sz29Z8AMWsRkUHXMJcOfLCRaO1Yo0bKvenWq/3rK88yGydW4db+gAjY5uoJ2YU2P30tLQUZM68wK4Aw4Iy4YD5aUxSRYwqSxQ2jfTDdTuG90AwUHTumACDbRs7I14BLujdrt9gww2k3ARmNR8owWWbxYM7hoDy1G7TTuQDmiBujSlg6mpAVeuDRAtoD248ZhFtueA9AAS7OAxhIcf37uNPWNTGpra/pvm69N1+w9/eaUC90aVpwAAAXh6VFh0U01JTEVTIHJka2l0IDIwMjAuMDkuMQAAeJwlkjtuIzEQRK+yoQRQRP8/cCjAoTfY0HA0uU7gw281hQGImQJfdbE4z+fz3+377+Pn/l6/Lr5un/fr9njJhfXS64VH73iBcN2+7i98zJaL//zeHrrFNHvZdvPg9QFFXdSXbrJ2g2I7SSSWbG13OUoxlS7a1W3eb4wtA1I2VQek2EpRvXgTFb255tZeD9reEVQHjCyy9eBtWjEgBkmxzrYsC7OjCbcff2YThQTfAjtkSARS0JZQ1hiyU6JGckkrB+ikZQBlE6tN+qRKOkoKM+OEpCy5PmyLkOoI2WOD5FLEaMXQhY+AOVYoLjKMxyMUI0eQbIRhIO0FRMnfcyPSfMKBEJ4tXp7nAEWIPYxNi2gF9ok5oMtnj253HV/bFqm8UImzFcrxjcr5KK1CJy7uBzGnIy/MnLbQn9qxFsEMVEMWxHTMG4fh0zN+hCF1Z067c0M593LcLWXdf/8DMjWCK33TS9MAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f0bdd139490>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f5820cce760>"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11092,17 +11201,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAXJklEQVR4nO3de1hUdf4H8PcwDDBc5CIiMASKkoBbqSAJKN61zHLd1ltr3kMqL4WZtm2rpl30Z5Zoq+IldTVdV4m0THTFC6A9hoq6omSEcncGkRlgZhzm8vtjzNqSS87InNH36y+ec758z+c8zzzv5/s933MRmUwmEBHRvXKwdQFERPaNMUpEZBHGKBGRRRijREQWYYwSEVmEMUqtzWAwJCYm5uTk2LoQIutgjFJr27Rp0/r164cMGbJ//35b10JkBYxRam1TpkxJTExUq9UjRoz47LPPbF0OkaXECxcutHUN9HBxcHAYPnw4gCNHjuzdu9fDwyM2NtbWRRHdO8Yo2YBIJOrXr5+Pj09GRkZGRoZWqx00aJCtiyK6RyI+DEo29M9//nPKlCl6vf6VV15ZtWqVgwOvMpH9YYySje3bt2/MmDEajWbcuHFbtmyRSCS2rojo92GMku0dO3bsueeeU6lUAwcOTE9Pd3d3t3VFRL8DY5QE4fTp08OGDZPL5TExMfv372/btq2tKyJqKcYoCcWPP/44ZMiQwsLCyMjIgwcPymQyW1dE1CK8ok9CERoampWV9dhjj+Xn5/fu3fvKlSu2roioRRijJCABAQGZmZkxMTFXr16dO3eurcshahFO6klw6urqOnTo4OXllZGR0alTJ1uXQ9QMxigJjlar9fDwMJlMKpXK1dXV1uUQNYOTehKcCxcu6PX68PBwZijZBcYoCU5eXh6Abt262boQohZhjJLgnDt3DoxRsh+MURIcjkbJvnCJiYTFaDR6eXnV1tYqFApfX19bl0PUPI5GSVgKCwtra2uDgoKYoWQvGKMkLJzRk91hjJKwMEbJ7jBGSVjMMfrEE0/YuhCilmKMkrBwNEp2hyv1JCAKhcLPz8/Dw6OmpoYfFCF7wV8qCcjZs2cBPPHEE9bPUK0Wly5BrbZyt0SMURKU8+fPA/Dw8LByv8XFmDYNubl45RWcOYOdO3H5spUPQQ8xTupJQLRabXR09MWLF2fMmLF8+XJnZ2fr9Pvuu3j+eXTtiooKLF2KTz6xTrdEADgaJUFxcXF58803pVLp6tWro6KiLl68aJ1+6+vRpg0AeHqirs46fRL9hDFKwjJhwoTs7OywsLCLFy/GxsZu377dou7KyrBlC4YOxcaN0Omwfj2eftpKlRLdxkk9CVFtbW1SUtLnn38O4MUXX1yzZo2bm9vv7iUzE+PGoaoKGRlwcMDx44iJwbBh1i+XHm6MURKu9evXz549W6PRDBnSKz19g1TataX/aTIhJQVvvAG9Hv37Y8cOtG9/PyulhxpjlATt0qVLY8eOXb1a6u5+Tib70M9vdvP/o1Jh8mSkpUEkwptv4r33IBbf/0rp4cUYJaHT6erLy2feuPEZAB+fvwQHrxGLG70jSq0+XVHwRsdBpxxEUmzbhqeeasVK6SHFGCX7cPPm7mvXphkMSienDqGhO93cnvxtG4ViXWnpa0ajNrD2LwGh7yM4uPXrpIcQY5Tshlb7fVHRGLU6TyRyDgpa6uc3CxCZdxmN2pKSGVVVGwH4+iYGB6eIRFa655SoOYxRsidGo7a0dI5C8Q8A3t5jQkLW1tefkkjaFRVN1GguODi4h4Ss8/F5wdZl0sOF942SPXFwcAkO/rRTpy/EYm83t6irVyeaTIaGhiqx2NvFpUt4+ElmKLU+jkbJLjU0lEkkAYWFI318Jnh5PWsw1Dg4uDo4uNu6LnoYMUbJjhmNWqXyS6Vyf4cOW2xdCz28OKknO1Zff9LZuYvBoLR1IfRQc7R1AUT3yGColstTRCKRpycfkydb4miU7JXD+R/9F1xFenpx8UyTSWfrcujhxdEo2acffhBt2eYWMEhaVaq8VaWrOO3s/yRa9s780tLSrVu3Xrt2DUB1dfXq1avb84l7sgBjlOzTwoVITYWrq3TSHtf8qoaKA87P9EBzr3k2GAyLFy9etmyZl5dXRUWFeWNUVNT8+fPvf8X0wOKknuyTyQRXVwDGJ8IdNKiNlTSboVVVVU8//fSiRYv0en1sbGxUVJRYLAagUqlao2B6cHE0SvbJZEJDAySS+u+C3y/d73hu4Pr1TTU/e/bs888/X1RU1K5du507dxoMhiFDhgDo2LHje++910o10wOKMUr2ad48zJ4NDw+Df+TmHU/3qG+q7bZt26ZPn65Wq6Ojo/fs2RMQEDBgwAAAoaGhmzdvFolErVQzPaB4+z3Zt5oaeHvD1RW1tXdZYdLr9X/729+WLl0KIDExcdWqVU5OTtOnT09NTQ0MDDx16pRMJrNB0fRg4WiU7JuXF/z9UVmJkhKEhPzPrrKyslGjRp08edLFxWX16tVTp04FsHz58tTUVKlUmp6ezgwlq2CMkn0zmTB2LAwGANBq4eJye3tWVtbo0aMrKysfeeSR3bt3x8TEAPjmm2/mz5/vFhExY8WKqx06hOh0fk5OtqudHhCc1JN902gQHIz//he1tfj3v/HWWwCQmpo6Y8aMhoaGbt26ZWRk+Pn5AcjPz4+Li1MqlRN27Hht+PAAJycfR0enlt1qStQE/obI7g0ahHffBYArV/DqqyWxsbHTp0/X6/Vt2rQpLCxUKBQAioqKBg0apNJoYg8flsXEHK2p2X/jhpiLS2QNnNST3WvfHqGhOHIECgVyc8tu3jzr6emp0WhUKlXv3r19fX1zcnL+/Oc/Ozk5mXQ6ibd3rcEwycdH5uzMGCWr4GiUHgSvvordu2E0Xq6sTNbpdEqlUqfTJSYmZmZmpqWl9e/fv7KyslOnTl9//fXWsLDH3NykYrEbPxdKVsLRKNk3R0fExkIsxqRJVyZNmgecNJng5OT06aefTpo0KTk5edWqVQASExM//fRTR0dHAH9ydm7jyF8+WQ1/TGTfamqQn4/q6uo5c0brdCOAvQBkMtnw4cMHDx589OhRFxeXtWvXTpw48c6/+EoktquXHkCMUbJvRiM0GtPAgQMrKq4DLuZHkl5++eVevXpdu3YtKCgoLS2tZ8+eti6THmS84Yns2/Xr6NGjuLx8O+AmFt8yGN784x//mJGRodFo4uPj9+zZw5fg0f3GJSaymvh45OcDwKxZrXfQ/fv3l5fvlEgWBAZuNRgMHTp0SE9P12g05vUlZii1AsYoWU2nTli2DCYT1GpUVbXGES9fvjx79nTgv9HR0eXlhU5O31+9etXJyWn9+vXr1q1z4hNK1Cp4bZSsRirFsGHYuhVaLdq1Q3AwBgzQdOmysmfPntHR0Z6entY93Pnz51977bXa2tLAwMPff39LJFLqdJ/5+/vv2bMnLi7OusciagJjlKxpxAi89BKqq+HhgeJi5OfXbN78FoBRo0atWLEiKCjIWgfavn17YmKiWq0GUF5eDsDd3T0sLCw9PT04ONhaRyFqCU7qyTpqaxEYCABvvYW4ONTU4OJFvPFGzYwZMyIiItLS0qZPn26VA+n1+vnz548fP16tVo8fP/706dPmdB46dOiJEyeYoWQDJiJrWLnS5OhoWrz4LrtKS0sBeHp66vV6C49SUVUVHx8PwNnZec2aNUajcdSoUQDCw8Nramos7Jzo3nA0StaRmgq9HpGRP28xGo3nz5/ftm2bTCbr0KGDUqm8ePGiJYfIq6ubWl4uevRRmUx29OjRpKSklSuv7tt3yNvbe+/evVa/9krUQoxRsoJjx3DxIgIC8OyzWLsWBQUAYP5y3IQJE6qrq/v06QMgKyur5X1u2bLlww8/NH/8A8DncnnS999f1+l6zp179uzZXr16ffEFkpM7hoWV7Ny5Oyws7P6cGVEL2Ho4TA+CsWNNgGnBAtMPP5gcHEyurqbaWpPJZEpISACwb9++devWARg7dmwLO7xw4YJYLDY/kvRYjx6zz+RF5eZG5+b+X3Fxg9FoMpny801t2pgA00cf3b/TImoRrtSTpeTyG/n5zo6O7tOmYdUqGI0YPRru7gDQp0+f48ePZ2dnmx9pb/lodO7cue5xcdHjx8vLy/VBIdlGvaNB/F7nkIE+3gC0Wjz7LFQqjB+P5OT7dmJELcNJPVlq06b15897TJz4oZ9fw86dJgBJSbd39e7dG0BWVlZ4eLifn19ZWVlRUVGzHWZmZh44cMCrc+eb+/f/LTJyaE0vdYHr+XFdFv/J+9AhALh+HcnJ6N0b69bdv9MiainGKFnEaDSmpqYCGDWq++7d/1YqO77wQsaTT97eGxcXJxaLc3NzNRqN+Zb4ZgekRqNx7ty5ANq3b1/dvfua69ffT+6yom2El0bq7Y2kJBQXIy8PMhmysuDqen/PjqglGKNkkQMHDhQVFYWGhg4ePHjt2rVK5bW+fa/d2dumTZvHH39cp9N999135pFpdnZ20x1u3rz5zJkzMpmspKSk6l//Wj1ggNTB4amhOHMGr7+Ol166/b0QIuFgjJJF1q5dC2D69OkFBQXZ2dkeHh7jxo37ZYM76dmSxXqNRrNw4UIA7du3b1Crnx85smvXruZd/v5wdYWPD3r1wjff3J+TIbonjFG6d3q93mAwuLi4TJ482cXFZdq0aUlJSR4eHr9scyc9e/To4e7uXlBQIJfLG+tw+fLlJSUlYWFhZ86c0R469OHMmb9tM2UKLLv9lMjK+L5Runc1NTXe3t5SqbSurs6hkS8VV1RUBAYGtmvX7vr164MHDz58+HBaWtrIkSN/21Iul4eFhalUqi5duhQUFCxZsuTtt9/+ZQOVCrt2wcsLkZFo1w7t2t2XkyL6vTgapXvn5eUVGBio0WiuXbvWWJuAgIBvv/22uLhYJBKZn+NctmzZvn37KioqftXy73//u0qlioqKKigokMlkr7/++q8atGmDjz7CqFEwGpmhJCC8b5QsEhkZWV5enp+f37Fjx8baPPnTyn1tba05VZ977jkAAQEBUT/x9fXduHGjo6NjZWUlgCVLlrjebRm+rAwArPeiKCIrYIySRSIjI//zn//k5+c/88wzTbesr6/fvn27XC4fM2aMQqHIzc2tqKj46quvvvrqqzttkpKSJk+evGHDhgkTJvy2B6UStbVwc4OXl5XPgsgSjFGySEREBIBLly412zIlJUUul8fFxe3cudO8pby8PCcnJzs7+/Tp06dOnQIwZMiQmJiYmJiYu/ZgHorKZNaqncg6eG2ULPL448/FxFTI5aubblZXV/fxxx8DWLRo0Z2NgYGBo0aNWrlyZXZ29quvvtrQ0HD27NkmOiktBTijJ+FhjJJFHn008NQp/6ws16bv+EhJSVEoFHFxcYMGDbprA/P2w4cPN9EJL4ySMDFGySK+vmjXDirV7Yy7q7q6uk8++QTA4sWLG2uTkJAgkUhOnTqlUqkaa1NWtsTXt2vnzustK5nIyhijZCnzq5rNn1a+q5UrVyoUivj4+AEDBjTWxsPDIzo6Wq/XN/G0aGlpaVVVvo+PzqJyiayNMUqWiogAGo9RlUq1YsUKNDkUNRs4cCCAzMzMxhqYP0Zixe/iEVkFY5QsFRuLwYNvf88OwLlzKC5GQ8Pta6UrV66srq6Oj4/v379/0/2Yx6pNXB4tKysDY5SEhzFKlsrIwIwZGD0as2YBwLBhCAlBly5PBQYGnjlzxnxVdMmSJc32ExcXJ5VKz507p1Aofrm9rKzs/Pnz+Gk0KuMdTyQwjFGylLs7vvgCdXVQq7FrF9q2hb8/FIq8ioqKXbt2VVdX9+/fv1+/fs324+zsHBcXZzKZjh49at6iUCjmz58fFhY2ZcoUlUp148YNiUTi5+d3X0+H6PdijJIVvPEGPvgAJhPGj8eFC2hoMNXVyb28vMxD0QULFrSwH/O8PjMzUy6Xz5kzJyQkZOnSpbdu3XJ2du7WrZu7u3unTp30ev19PBOi348xSlbQtStEIpSUYOxY9OuHxx+vc3FxqampiYmJ+fjjj/v27dvCfsyrTF9//XVoaOiKFSu0Wm10dLRMJjtx4kRRUVFDQ8Ply5fT09Pv56kQ/W58UR5ZKjUViYmoq8PSpfjlarxCodBqtY888kjLuzIYDL6+vjU1NUFBQd7e3iqVyvzuqNDQ0Hnz5mm12tmzZw8aNOiQ+ZNMRMLAGCVhGTFixN69e/39/c2vegoLC3vnnXdeeOEFsVisVCplMplarS4oKOCH6Uk4OKknYfnDH/5gztCQkJB169bl5+e/+OKLYrEYgKen5+jRo00m08aNG21dJtHPGKMkLPX19ZWVlSNHjrxy5UpiYqKj4/+8hCwxMRHAxo0bb926ZaMCiX6NMUrCYv7m3axZsyQSyW/39urVq1u3blVVVV9++WWrl0Z0d4xREhCVSnXu3DmJRNLYK0cBTJs2DUBqamor1kXUFMYoCcjJkycNBkN0dPRdvyBiNn78eDc3t8zMzCtXrrRmbUSNYYySgJhn9OZvMjfmzkLThg0bWqsuoqYwRklAysom9umzuW/f4U03My80bdq0iQtNJAS8b5SEQqeDtzc0GlRVwcenmcYRERH19fUHDx4MDw9vleqIGsXRKAlFbi7UanTt2nyGAvDx8SktLS0pKbn/dRE1gzFKQpGVBQBNXBdNS0sbMGDAjh07dDpdXl4egO7du7dWdUSNYoySUJi/HtK7d6MNDh06dOTIkeLi4u+++06tVnft2tXX17fVyiNqDGOUBMFkwokTQJMxevz4cQAJCQl3/mil4oiaxBgl2ysvR3U1Nm7Ea68hOPjubaqqqi5duiSVSqOiolpyXxRRq3FsvgnRffaPf6CyEhs2YN++RttkZWWZTKbY2FixWHzixAlwNEqCwdEoCUJoKA4caKrBnRFoXl6eUqns3Llz4J2v6BHZFGOUBGHqVGzdiibupueFURIsxigJgoMD5sxpdFKvUqny8vIkEkmvXr14YZSEhjFKtjdiBDw8EB6OSZPw7bcA0NDwPw1ycnIMBkPPnj2lUmlOTg44GiUh4RIT2V7PngDwwQdIScEPP0Asxo0byMn5uYF5BJqQkHDp0iW5XC6TyUJDQ21ULNGvMUZJKCZPxoIFOHgQbm5QKnH2LO48ozR69GipVDp06FBeGCUB4qSehMLfH8OHQ69HZCQAfPaZ4c6ubt26vfPOOzExMbwwSgLEGCUBSUwEAJFIHh+fumtX5/r6+l/uraysNH9amaNREhTGKAnIkCFISHj5xIn2N2+uvH796q5du8zbi4qKZs+eHRoaqlar33777UjzeJVIGBijJCAODhg8WAbAzc0NwJYtW/Ly8saNGxcWFpaSknLr1q2hQ4cmJSWJRCJbV0r0M762mYSlsrIyODgYwKRJk4qLiw8ePGgymSQSydixY+fPn89xKAkQY5QEZ+TIkenp6ea/3d3dX3rppeTk5KCgINtWRdQY3vBEghMREZGbm6tUKpOTk2fOnNm2bVtbV0TUFMYoCc7Vq1dLS0tTUlJmzpxp61qImsclJhKc7OxsAAMHDrR1IUQtwmujJCyFhYWdO3f29fWVy+VckSe7wNEoCcuxY8cAJCQkMEPJXjBGSVjuvIXE1oUQtRSXmEhYbt58Kz4+NiEh3taFELUUr42SgJSVISgInp64cQNisa2rIWoZTupJQI4dA4DevZmhZE8YoyQgx48DAK+Lkn1hjJKAMEbJHvHaKAmFQoH27SGV4uZNODnZuhqiFuNKPQlFeTkeewzt2zNDyc5wUk+CMHMm3N1x7hwGD8b779/eeOcPIiFjjJIg3Lx5OzQLClBQcHvjnT+IhIyTehIENzf07QvzR0Nqa/HXvwJAYaFtiyJqEcYoCcW4cZg8GQYDPDxuj0wnTrR1TUQtwEk9CYKvL0QizJsHJyf4+d3e6OeH9HQsWoRbt2xaHFGTeMMTCd3q1Zg6FVKpresgagRHoyRoW7ciMJDPhpKg8dooCVr37tDpYDTaug6ixnFST0RkEU7qiYgswhglIrIIY5SIyCKMUSIiizBGiYgs8v9FTHFHUrOO9wAAAo96VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHWRbUhTYRTH733udvfuNqe7a7q7i1MTar05tCC6zzkRi/JDKr2IGI9+ulEQCoaUpFISfihxYm++hGBKjqBZ1pdaRRH0YlhB9EEi+5RhmiHUh8A2phhaBw4/+P//z+Ecntn4zY9coqyJ5rlU+ROdk+hmXmQFCQo6kW1NktctC4tUNv1FssyVudWD/jfxH4lV0ZWOSVGS+y/CoKRkwZB6sMyUQVYZRiV57wK/RIeS1PU6C2dknFMjnKTwRCO8xIjAiE0RTBoRPEyn5/QiJ8qcwagRg4sZ3IoxgzOZmUliZotGLFZm9WjEukaxpWnE5mBpXmb3asSexRxZGnGmM2cml+7SiFvmsmXOJ3MZOj1PBJMkGlzpTs4omi1Wj2AS07z2LIdN4pc+yb/uXA01awNw93Y29s1a6JeKftDvysPvQ6/V89IVqNtTgG3wS82V2oGW52HVxAm1auINPAta8VOPnmodz6H6iRU3LEyp91vjUFtpxsmTDTSmRmEu5ML28n2049sA7AxKmHNsPS1bG4GmYQULC8M08rINpqkPSwa30PcHTkO4TsaeQkJHBxtgLhDA0eJD6quqq7C7OojBEZv6dPMASD83YtF238PH23rg4HQROqYu7ZCHOhI7b8If0Emd4Sj0u2Xs3n+DNk7GIKPJi6HmXsqPxWDEl4kzjXbq6eqD4dpM9D66Rn9fjkI9BvDIcUbPlEbBcMuG3tIiOtjdC/0XFSz2jqv+1rMwdiof5aEPakt+DbQezcX6Tk/8TsV1aOkK4deut3FnOAL3PoewMraXXhBjMFYioH8+QgMvHsDIjBHn5stobHwU3h02ofsPPIW7Mhe0pJwAAAKselRYdE1PTCByZGtpdCAyMDIwLjA5LjEAAHiclZZJilsxEIb3PoUu4KImlaqWoZ0BQjqQQO6QVTbp+6c0vGdDd0NkDNb/yvpco2R7efkDHy6lv37cvv7+W86X3C6XIlRES8E33xFRfjEijv0CVaLmghFqRe+PAqjVWp7Ke4jH96AwkNuikHnkSgmEmu5QCIy0Uyg9kMFTBmzc9igxI6IG7ibLFyHZoSCEad/LBixsPS8VUHXLl/TeW+uLChSGk0KRed6KyNmpUwScavdKFKrHVkS513nUiEDROk8MHGkrIgGulWaljWZEDVoo7+XFQjuFHNiCe41659hW1wkQ8ao0s+rs3Sz0Vtdxek99L1XwMJ4UI7LNSosuSlVsM6LmmautrnNVmxPAUfs0qoBoxT1KrXLMNI8uTkrE1gRce32Vpy+VfdSoQpO93sWMw9qqNFqPTRXQ9k4GBUPyo3ejzRpV5q3s1vSFxjRyzvToYnEw1i2KQjDFovCkZP+12KpR7lXGmV1n9kkRIyyftnwJ5pUXjdV1Tho7lLwD0I7skvo8pbRH+bwTkau3GVFDwjXT2miHkncAj74ng2oV5+ltjFu+5I4YZzZp3iRjLpNCmLz/p1y794HrrDP3OQGktklRIlkT4NomJVtXdyLKs8559S7NaZTMOGdE319T6N1+qcEyb5LG0uZNwnk57lCkzzRPX1oe35Mimhn/+Zryxh+Ry2DH/IUh+nDzIVhPSz6T08KPFhnkU9BdaOnNx4foN8Sy5MpOkat2itb/Mx3Ch298CMYHS8/eEpHzcoj8RXoUd0fzMfFByxWdgFx13/gUp28ZDN0tKU5H8zHfhQ3Bp/DT0oZYFi905jpFPzCWiBHc/FpGds8Bx4MQvItvpTx9+Tz25HfKNR+mOT+75ePz7fIPeDGqob9+SmgAAAG4elRYdFNNSUxFUyByZGtpdCAyMDIwLjA5LjEAAHicJZI7jhtBDESv4lACWkTzT2LCBTZcBw4NR5PrBHt4F3shYKB5U10ki/3x8fHn8ff369/z5/l18/34fN6P11tuPG+93/jpE38A7sfX842Xkdz86/uxqcN0SZCoxFKnbZaX0K7MJU7ch3LvuphKipcoFbsuNfJqvZSkQ5YIpUQPVpMA5pIczFKyVHDaL5xp0fFI0RyxqDLEvqOWMBlbTUUTbuDCoYN38NKg2pxT0R2NbApGe0nZJmhaTBY36kgN1TjG2j5S9w3axOkObVnliHPzsk1syaBcccQc1cuYlNMwd7D5iFnx2ZBOSl4bHhaDpb2WKeb2awrpT0FBsqDdrNdrSvRpOQpiRGoxFNanaZ+QgFORNLgx6+IiKcvhImwwR9R58I5YZrTjNNgzJCfiCj19K2oKRRsfdbScKSN8FsNy1CJmEwnEBnU222KnmnUCB3PMVVA72G3nmGQ5TyaNC8OGTPAZJXn7UEEUHOQT1Lzuxs5j889yd+c4O6YB7hY52Po4FyK6MGrzuTeiWLIWTOyocSMOlsHoPvv5/R9bA53yALWZzgAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f0bde86a9e0>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f5820cce3a0>"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11113,7 +11222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [
     {
@@ -11147,17 +11256,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvomK+y5uIKJkWmJp4laiP/NaSYleLaybNm6Ja3fQFnJJx9stqW4ZZiqaaWSmGGoQKiCmSYgoKjIMw7DNMDPP74+DI+4IszDM9/3qxWvmcHieZ0w+fs95znkOjzEGQgghjcW39AAIIcS6UYwSQkiTUIwSQkiTUIwSQkiTUIwSQkiTUIwSctv58ygrq3t94QI0GouOhlgJilFCbps5E6+9Vvf6n/9EcbFFR0OshNDSAyCkedFq8cMPGDMGAGprUVyMigpotVCpoNOhvBx6PZRKAFCrc6uqjpWVlTHGuK9KpVKv15eXl+t0unnz5vXt29fFxcWyH4eYAcUoIXdYswYvvoinngKAAwcwZ84D9xw+vOTXX2c96LuZmZmDBg363//+Z4IxkuaFYpSQO/j7Izoaa9YAgFgMHx+IxRAI4OoKPh9ubuDx4O4OAN27u3btGuPm5sbn87mvrq6uAoFALBaXlZUtWLDg66+/njZt2nPPPWfZT0RMjUc3gxIAaWlpS5cujYiIWLx4saXHYklPPoldu+DmhqFDUVqKQ4fQpk0jm1q7dq1EIuncuXN2drajo6NRh0maF5piIgBw6dKlw4cP5+TkWHogzYJQiI8/xsWLTWrkX//6V79+/S5evPjee+8ZaVykmaIYJQBQWloKwMvLy9IDsaTDhzF5MlxdASA0FMeOwcenMe0cOHBAr9cLhUKZTMbn8+Pj48+dO2fcoZJmhWKUAIBcLgfg6elp6YFYjE6HuXPxxhvYu7duy+DBcHB47HZmzpw5evRomUwGIDQ09LXXXtNoNLNnz6azZy0YxSgBblWjthyjn3+Oc+fQoQMiI5vUDjehtHDhwqKiIgBr165t1arV0aNHv/jiC6OMkzRDFKMEuFWN2uxBfU0NVq4EgPfeg719k5qaOHHiuHHjysvL3377bQBubm7r1q0DsHnzcbncCEMlzRDFKAFsvhpdvx6FhejbF5MnA4Be36TWNmzY4OLisn379h9++AHAtGnTYmJO/vHHlnfeMcZYSfNDMUoA265Gy8oQHw8Aa9eCz4dOh9BQSCSorGxkg4GBgcuXLwcwb9686mo1gAULQoVCfP45Dh821qhJM0IxSgDbnqmXSlFaimHD8MwzAJCYiD/+wI4dsLNrfJvz5s0bMeJlb+/UNWscAHTujEWLwBj++U+o1UYaN2k26PJ7AgCenp4KhUIul9vacX1REbp0QXU10tIQFoaaGnTrhsuX8fXXmDq1SS2npyMsDEIhTp1Cz57QaNCvH86dw5o1sO1bHFogqkYJdDqdUqnk8/nu3E2OtmTLlhNCIXvhBYSFAcCGDbh8GX36YMqUprY8cCBiYqDRYPZsMAZ7e2zZAh4Pq1cjL6/pAyfNCFWjBHK53Nvb28vLq6SkxNJjMasLFy706tXLw6PzsWMZXbs6l5Whc2fI5ThwAM8+a4T2y8vRoweKivDZZ5gxAwBeeQWJiXjmGRw8aIT2STNB1Six3WvvFy9erNVqJ058smtXZwBbt/5dVobhw42ToQBcXfH++wAwfz5u3gSADz6Ajw9++gnffmucLkhzQDFKbHSaPj09/fvvv3dycnr33XcBXLt2bcWKoI4dJ65bV23EXqZOxbPPwsGh7kDeywtSKZydUV5uxE6IhVGMEhu9aHTRokWMsXnz5rVp0wbAihUrqqqq+vQRhIQ4Gbejzz7DuXN1514BzJiBtDT88gtKSwFAocDy5cbtkJgbxSixxWr04MGDhw4dcnd3X7BgAYC//vrrs88+EwgEq1atMnpfAQFwc7v9lseDmxtSUrBwIQBUV+PIEaP3ScyKYpTY3EWjjDFuWdXFixdzNfiSJUtqa2ujo6N79OhhnjGEhqKoCGlp5umNmBbFKLG5g/rt27dnZmYGBATMnTsXQEZGxnfffefo6MidJDWbjz7CvHnQas3ZJzEJeogIsbmZ+n379gGIi4sTiUQAqquru3XrNnbs2LZt25pzGF26YPRobN5szj6JSVCMEps7N+rj4wOgoqKCezt06NDs7GyNJZ5Jv2gRQkLg62v+nokx0UE9sbmD+lGjRgFYvnz5lStXuC1CoZCrTM2Dx0PnzgDg5IT330fXrmbrmZgExSixuWp01KhRkyZNUqlU8+bNM3/v1dUYMQIODqipAYDRoyGTmX8UxJgoRm2aWq3eunVrXl6el5eX7VSjADZs2ODu7v79998nJyebuev163HxIlJSmro+NGk+KEZtlEqlio+PDwwMnDVrllKp3LRpU4cOHSw9KPPx9/dfuXIlgDfeeMNwktQMysqwdi0ArFsHPv3ytRiM2BilUimVSg21Z79+/ZKSkvR6vaXHZW46nS4sLAzA/PnzzdbpO+8wgA0bZrYOiTnQCk82pKSkZOPGjR9//HFZWRmA8PBwiUQyduxYS4/LYrKysoKDgwH8/vvv/fv3N3V3d61tSloOS+c4MYcbN25IJBLDZHR4ePjPP/9s6UE1C9ws08CBA3U6nan7eu01BrCoKFP3Q8yNqtEWrqCg4MMPP/zPf/5TXV3N4/HGjBmzdOnSQYMGWXpczYVKperZs+eVK1c2b948e/Zs03V04QJ69QJjyM6Gue44JeZi6RwnppKXlxcbG+vg4ACAz+dHRkZmZGRYelDN0c6dOwG4urpevXrVdL08/zwD2KxZpuuBWAzFaAuUk5Mzffp0oVDIBWhUVFRubq6lB9WsjRs3DsDUqVNN1P7Jkyd79ZoxaJDclEFNLIZitEU5ffr09OnTBQIBAHt7++nTp1+4cMHSg7ICBQUFLi4uAH744QdTtP/000/j1gqnpOWhGG0hTpw4MXr0aO5EjZOTU2xsbGFhoaUHZU3Wrl0LoHPnzlVVVcZt+ccffwTg4eEhl8uN2zJpJmiKqSUoLi5euXLlpk2bXFxcoqOjJRJJQECApQdlZbRa7cCBA0+fPr106dK7Fm/ev3//lStXdDpdeXm5Xq9XKpWMMe6iMYVCAUCpVOr1+vLycp1Op1KpMjMznZ2duZ9ljIWEhGRmZq5bt27+/Pnm/1zEHCwc48QYEhMTAfTr14/qnaY4efIkn8+3t7c/e/Zs/e2Pe0lpSUmJ4We//vprAK1bt66srDT7ByJmQgvltQTc2iLDhw+3qfvijS40NHTmzJkymWz27NlHjhzh8Xjc9rFjxw4cOJDP57u5ufF4PHd3dwAeHh4A3Nzc+Hy+q6urQCAQi8VCodDFxYXbAUBtbe2yZcsArFy50pwrSBEzoxhtCWxtpTvTiY+P37t3b2pqamJi4iuvvMJtXLFiReNa27p168WLF7t16/bSSy8ZbYik+aEYbQlsbaU703Fzc1u3bt20adPmz58/ZswYboHn+zKcCdVqtRUVFbW1tZWVlRqNpqqqSq1W19TUlJWVLV++HIBUKuUuPiMtFf3fbQmoGjWiF198cdu2bSkpKSEhIZ07d37QhFJDmurfv/+AAQPGjx9v2hETS6MYbQmoGjWuSZMmpaWlXb58+fLlyw/ax3Am1M7OztnZ2d7eXiQSOTg4ODo6Ojk5OTg4iESisLCwGTNmmHPkxCIoRlsCW3tCsknpdLr169dXVlbOnTt34sSJ9SeU3N3deTweN6Fk6WGSZoRitCWwtUd7mtSXX3559uzZ9u3bf/DBB9yKBIQ8HC3A3RJQNWosGo2GWxV/1apVlKGkgagatXqM1f76q79W25W7K5w0xcaNG/Pz84OCgl588UVLj4VYDYpRq6fVyhn7y9HRz3C5OGkc7vlUAKRSKZ+elEQajP6uWD2tVg5AIKAj+qaKj48vLi4eOnToc889Z+mxEGtCMWr1dLpSAEIhzS81SXFx8fr16wFIpVJLj4VYGYpRq8dVo0IhVaNNsnz5cpVKNWHChCFDhlh6LMTKUIxaPa22FIBAQNVo4+Xn5//3v/8VCASrV6+29FiI9aEYtXo6HVWjTbVo0SKNRvPyyy/36tXL0mMh1odi1Opx1SidG220M2fO7Nixw9HRMS4uztJjIVaJLniyHK0W+/ahoAC9eiEiognNcDFK1WgjvfPOO3q9/vXXXw8MDLT0WIhVooeIWIhOh2efxRNPICQE+/ZBp4NEgv374eaGl19+rJZKSj5VqQ55e88Wi4eZaLAt2JEjR4YPH+7m5paXl0e3gZHGoWrUQvbuRbt2WL4cACIjMXgw1GrMmIHHvOq7puZcefnPWu3NiopfKUYfF2Ns4cKFACQSCWUoaTSKUQs5exbBwbffhoQgJwdDh8LLC56ed3z19KwYE6D3dhYIvIRCT6HQWyBwM/xcQUFMmzbrRKJgjeaBS7o9Wm0t8vPh7w9X1yZ8JOuzc+fOEydOtGrVKjY21tJjIVaMYtRCxGJUVNx+W1EBxqBQQKG4d9+rg/tUKLIMb3k8ARep3t4xPJ6guvqss3Oog0MntfpiVdUfQqH3rcD15PMbcJf9Dz8gLg5hYfjzT/TqhQ8/xN9/A0CHDmjRa7brdDruQUlxcXGGB3kS0gh0btRCcnLw2ms4ehT29lAoMHgwTpyAXg+5HKWldV9vvbgyV1styNfpSrXaEq22VKdTcm0EBKzy9JxSVLSsqiqzVatlOp3q8uV/1u+Ex3MQCj0dBO27zbG7o8jl/vP0RI8eGDoUJ07AwwMAoqLwj39AowGAyEg4Od137Evy86+p1Y58PoAVHTr42NmZ8k/KVLZu3Tpr1qwuXbqcPXvWzjo/AmkmWnK50az17o0ZM/Dkk+jYEXl5+OgjcI+TvN+aoW3ufMuYVqcr1WrlAoGnnZ1fhw7faLU3c3P7tmv3iYdHlFYr576r1Zbq9ZW1tdcEOicc/fv+w/j2W/ToUZehAMaPx/HjeNTdkBq9fmG7dl0fELJWobq6mnsY/Zo1ayhDSRNRjFrOrFmIiYFCcd/ofAgeTygU+gqFvgCqqjKcnPozpuHx7Fxdn3Nzm1B/T8bUWq1cX6nAryW3y9uSeq9dXFB/IXc7u7pS9FFyKioUtbUigSDIeg6HlUrlxYsX8/Ly8vLykpOTr1y5MmDAgEmTJll6XMTqUYxaFI/3uBl6F6Xyh6KiZYCgffvPeDz7e5p3sLMLgHsAHjSHX1aGt95CbS24iuzYMYSFNaTfv2tqlDqdl1DYPGNUoVD8fT/19/Hy8ho0aBCtLkiajs6NWrfKyvQrV+aLxU8GBKxqZBMJCUhJQVQUzp7FmTPYv/+RM0sL8vJmBgQ0h4N6rVZbWFiYl5dnKDM5lZWV9+4sEok63VJdXf3JJ5/4+/v//fffTs3ggxCrRtWoddNoCioqjtrZPfBx6o/25pt49lmcOoUxYyCVwhoe1paRkfHuu+/m5eVdunSptrb23h28vLw63alz586tWrWqv096enp6evpnn302d+5ccw2ctExUjVq3mzdlly/P9vaOaddOZrZOfykr6+vi4mWhy6FOnDixbNmylJQU7q2Hh0fHenr27Nm7d2/ucZ4Pt2vXrueff75t27YXL160t7/7fAghDUfVqHWzyJrNA1xcRp4509bR8XtLrIf022+/paSkPPfcc2vXru3UqZOjo+PD91coFPWP91944QVucfsJEyYEBQVlZ2d/+eWXr776qlnGTlomilHrZpF1SZRaLQMsNTWTnZ0NYNy4cfcuateQmSV/f38uRnk83qJFi1588cV///vfL7/8srBF32tATIr+6li3Ww9iMms1qtRqAbhZ6CwqF6NBQUHc24yMjDVr1nCVZlVV1b37Ozs71z9DOnjwYMO3Jk+evGLFivPnz3/77bfTpk0zz/hJy0Mxat1uHdSbtxrV6QC4WaJ802q1ubm5PB6vd+/e3Ba1Wr17927u9V3nSTnt27d/0GM+BQKBRCKJjo5es2bN1KlT6WmgpHEoRq1baWk3YLBO1+bRuxoPV426WiJGL1y4UFNT07FjR9dbq6j06dMnKSmJKzbd3Nwe/uP3+sc//rFq1apz587t2rXrhRdeMPZ4iU2gf36t2yuvxIeGpt24EfzoXY2n7qDeEjGalZUFoE+fPoYtYrE4KipqwIABjchQAHZ2dgsWLACwevVqumqFNA7FqHWTy4H734hvQnUH9ZY4N8qdGK0fo00XHR3dunXr06dP79+/34jNEttBMWrduHX1zByj5ZauRg3zS0bh4ODw9ttvA+AWKyHkcVGMWjGVChoNxGKY+eJxC54bFQrn9O8/Pyion3GbnTVrlq+v78mTJw8dOmTcloktoBi1YhY5ogegPXq0S26ua1mZmftVKrFnz+g//1zXuXNn47YsEonefPNNAGvWrDFuy8QWUIxasdJSADD/M4QOrV+//aWX7O+3UL9JZWWBMfTubZL7/ufOnevh4XH48OFjx44Zv3XSolGMWjFLVaNyuRyA+Z8Bl5UFAEadXrrN1dWVeyLTe++9Z5IOSMtFMWodLl6EXl/3urAQlZX44w8EB+PIEaxejbNnzTqY0tJSAJ5mz+/sbAAw6vTSHWJjY8Vi8Y8//pienm6qPkhLRDFqHSZNgkpV93rBAmRmIiQEO3bgyScREoKoKPONRKPRVFRU2NnZubg04Hl5RsVVo6aLUU9Pzzlz5oAKUvKYKEatVe/e+M9/cOOGufs1HNGbed14xuqKbtPFKIB//etfIpFoz5493JVVhDQExajV2LQJH36IDz/E+fMA4OCApUsxf765h8Ed0Zv/xGh+PsrLERAAnyYsUX0vvV4fGxt78OBB7q2vr+/MmTMZY8uWLdPpdMbsibRcFKNWo3t39OyJnj1huOlxwgQoFDhyxKzD4KpR858YNcX8kk6ni46O3rBhw7Rp01S3TpqMHz/ezs4uLS3Nz89v8uTJW7duvXbtmjF7JS0OxajVGDECo0Zh1Cj4+9/e+PHHWLwYAE6exKefwgw3hVuqGpXLIRbj1rpORqDVal955ZXExERnZ+ft27eLxWIAGRkZkyZNqq2tra2tlcvlO3bsmDVrVtu2bYcMGbJ69erMzEy6757cByPWoG9fVlZW93rKFHb0KAsOrnu7fDnr3p1168YANno0u3LFhMPIzMwMDw93d3fv0KHD1atXTdhTPbt3s6NHGWNMr2c7drCiIiO0qVarJ06cCMDNze23337jNh47doxb3yQyMrK6uvrChQsfffTRyJEjHRwcDL8v/v7+b7+9eceO2/87CKEYtQ7p6UyrrXt99iwrK2MnT9a9ra5maWksKYl5ezOAubkxmcz4Azh8+HBERAQXJc7OzgA8PDy++uor4/d0j8mTWceOTKFgjLFp025/8EarrKx85plnuI9w8lZzv/76K1eQTpkyRaPR1N+/qqoqJSUlNjY2MDAQwLBhhwEmELDgYBYXxzIymF5/e+erV1lhYd3roiImlzd1tKT5oxhtOa5fZxMmMIAB7LnnmLGKxdTU1BEjRnABKhaLY2Njs7Kyxo8fz20ZM2aMqcvSyZPZkiVszhzGjBGjFRUV3Mfx8/M7c+YMt3H//v3cY5anTZtWW1v7kB/PysrasEE+bBgTCuv+qAHWrh2bPZslJ7PKSrZ0KQsMZCoVY4wtX87M8g8NsTCK0ZYmKYl5ejKA+fiw775rfDt6vT45OXnQoEFcXHp5ecXFxZWWltbrKMnDwwOAj4/Pd03p6VEmT2bZ2eypp9jJk02NUYVCwT1EpFWrVjk5OdzG5ORk7rB91qxZOp2uwU2xpCT2yivMz+92njo5sbffZhMnsvnzGaMYtRkUoy1QQQGLiKj7xZ49u1z+mAeWOp0uOTk5OLhuKWgfH5+4uLiy+50LLCgoMBzpR0VFlZSUGOkTMMaYXs927WLfflsXozk5bMgQNnUqO3mSffMNu/Owu0FKS0tDQ0MBtGvX7uLFi9zGb775xs7ODsD8+fP19Q/OH0dODpNKWUQECw5mS5eynTtZeDg7c4Zi1FZQjLZMej2TyZirK+vbN9bPz2/37t0N+SmdTpeUlNS9e3cuGdu2bZuQkFBVVWXY4fTp0zdv3ryzI71MJuPuaPL399+zZ0/TB6/TseRkNmAAA1irVuyFF1h2NmOMLVjAPDxYfDwDWGAgk8luny9+pOvXr3OrlHbt2rXw1snLL7/8UiAQAJBIJE0fNmNMrWZLl7Lvv2d//MGefJJi1FZQjLZkeXmlTzzxBJeJr776qlKpfNCearU6MTGxS5cu3M7t27dPSEiorq427HDq1KmoqCgej7dw4cJ7f/zvv/8eNmyYoSytf+z/WDQa9vnnrGvXulI6MJBt3Mhefpnl5jLGmErFundnmzezHj3qdujfnx048OhmL1++zH20Hj16GM7kbt68mXuG3YoVKxo32vviYpQx9vrrLCiIYtQmUIy2cFy1KBKJAAQGBv7888937VBTUyOTydq0qXsoXqdOnWQyWf1plqNHj3Lz2twc/bvvvvvIjtq1a3fo0KHHGqdazRITWefOdfnYoQNLSGD1YvwOOh1LSmIdOtTtPGQIS019YMv5+fmdOnUC0L9/f0MpvXbtWgA8Hu+jjz56rHE+kiFGlUoWEEAxahMoRm1Cbm7uwIEDueCIiYlRqVSMMZVKlZCQ0KpVKy4ig4KCEhMTtfWOk1NTUyMjI7nvuri4xMbGFj3qos2zZ8/e29HDVVZWbt2aGhBQl4k9e7KvvmrQ0bpazWQy5utb94MRESwr6z67paamikSiwYMHK7hrphiTSqXcCDdu3Pjobh7T1at112YVFrJPP6ULnmwCxaitqK2tXbVqlb29PYCOHTu++uqrhhs6Bw0alJycXH+CJSUlJSwsjPuuq6urRCJp+DxVbW2tVCrlOurQocORI0cetKchxwUC+/btNX36sMTExzjdeasRJpUysZgB7KmnDkZFReXn59+1z/Hjxw2BvnTpUgACgWDbtm2P19PjqK5mDg6Mz2eNPb1BrAnFqG3Jzs4eMGCA4RL68PDw5ORkw3e5OfqQkJBHztE/UlZWVv/+/QHw+fzY2Niampr635XL5XFxcdz1UgDCwsIOHsxp7Dw5Y4xdvcreeEMjFvsBEIlECxcuNNSeBnq9ft68eQDs7e137NjR+M4a5oknGMD27jV1P8TyKEZtjlqt5u6IT0pKMmzk5uh79OjB5Zqfn59UKq2srGxKRxqNRiqVcpcT9ezZMz09nTFWXFwcFxfn7u7OdXRXjjfR+fPnuXkw7g4lqVRquMxAq9VGR0cDcHBw2LVrl7F6fIglSxhQdwEpadkoRm0RV4oajnMVCkXHjh25XOvQocOWLVvuKh6b4vjx4926dQNgZ2cXHh7OzUEBGDVq1LFjx4zVS32///674bar1q1by2Sympqal156iStUf/rpJ1N0yklPZ//+d939Yz/9xAAWEmK63khzQTFqc9RqNXdgW3/js88+27Fjx7vm6I2lurpaIpHweLzWrVvzeLzIyMiTTb8x/lEOHjzInb4AwC044urqmvqQGX1jGDuWASwxkTHGKiuZvT0TCGgRk5aPYtTmFBUVcXdD1t9YXFzc8PsgGyc8PByAKSbHH0Sv1yclJXXq1KlNmzZisfj48eOm7vH99xnAoqPr3g4ezAC2f7+puyUWRuuN2pz7rrvs4+PDXYtuOlqtFoDhHlMz4PF4UVFRp0+fLikpqaioMPrT7e81fDiA2wtpc3ckmHldbWJ+FKM2x2zrLufm5u7cufM898wTyz1P1MXFJSwsjDFmhgfQ9+sHd3fk5aGwEKAYtRkUozbHbE8B2bNnz6RJkxITE+v3a/5l8wFwN6oeMX2eCQQYMgQAUlMBIDwc9vZQKmsqKqpN3TWxIIpRm2O2OKtffur1+rKyMj6fb7jUyZzMFqMAhg0Dn4/MTBUAsRhDhow/d84pLS3VDF0TS6EYtTlmO7iuX/aWlZXp9Xp3d3duRSUzGzx4sKOj45kzZ8rKykzd19NP54nF7fftG8i9DQnpCuDo0aOm7pdYEMWozTHbudH6Za+lnifKcXR0DAkJ0ev1Zjk92k6vLz1//jx3RQRXCP/666+m7pdYEMWozTFbotUvey14YpQzfPhwmOW4XigUcgvsc5E9dOhQgUCQnp5eVVVl6q6JpVCM2hyLVKOWmqY3MGdVWP9UrJubW9++fTUazYkTJ8zQNbEIilGbY+ZqtP5BvQWr0SFDhtjb2586dUqpVJq6r7tmtMw5wUUsgmLU5pgt0RQKBQBuGSeLV6MikSg4OFin06WlpZm6r4EDBzo7O+fm5hYXF4Ni1AZQjNoc8yRaeXm5RqMRi8XcwqNmO5PwEGaLM3t7+/fee2/79u3cEjBDhw7l8/knTpyoqakxddfEIihGbY55YvSu3LTsTD3HnFVhbGzs5MmTuRj19PQMCAjQ6XTjxo3btm3bjRs3zDAAYk5CSw+AmFVlZWVNTY1IJHJycjJpR3flZnOoRp944gmhUJiRkaFSqcRisXk6ZYy9+eabV65ccXV1TUlJSUlJAdCzZ8+xY8dGREQMHz5cKKTfQatH1ahtMfO1982qGnVxcenfv79WqzXbpDlj7I033li/fr29vX18fPymTZvGjBkjEolyc3Pj4+NHjhwZEBAwffr0b77ZXlpqnhERk6AYtS0WuRPUnP0+nDmP63U63YwZMzZt2iQSifbu3Tt79uw5c+bs27dPLpenpKRIJJIePXrcvHnzq6++Wr78e19fhIRg4UIcOwbGzDA6YkwUo7blvgfX3ISycd2VmxafqeeYLUY1Gs3//d//JSYmOjs779271/CEagCOjo4RERFSqTQ3N/fPP//88MMPhw+fKxTijz8QH4+hQ9GmDWbOxPffQ6UCgF9+QUhI3eujR7FiBd58E2fO1LW2fj127TL1pyGPQDFqW+49uL506VKXLl1mzZpVUVFhxI6aZzXK3VP0+++/m/SeIrVaPWXKlO+++87d3T0lJeXpp59+0J7dunV76623ZLJhJSXYtQszZ6JNGxQV4dNP8cIL8PbGiBHIzoZKhbg4AKiqglyO68dkHSIAAAcBSURBVNdhmPMvLUV5uek+CmkQilHbwqUb99A3TlpaWnV19datWwcMGGDEayqHDh26ZMkSrvrTarUqlUooFLq6uhqr/ca57z1FhYWFYWFhK1euzMjI0Ov1Teyiqqpq7Nixu3fv9vT0/Omnn7gbQx/JxQUTJmDrVhQWIi8PCQmIiABj+OUXiESYMAGnTuHUqdv7X7uG/Hzk58P0a62QBrDw6vvEvM6fPz9q1CiBQCCRSDQaDbcxOzvb8DDkmJiYJj4Q9F7cJT6+vr7GbbZx3nrrLQDLli0zbNmyZYvh18Hb2zsqKioxMbG0UQ+YV6lUTz31FAA/P7+srKwmDrW0lCUns+RkJpGw06dZeDjbv5+98QabMoVNmMBiYlhMDAsOZtu2NbEf0lQUozYnNjaWq0ZDQ0Nzc3O5jfd9GLKx5ObmAujevbsR22y03bt3Axg2bJhhS1VVFTfnwz3BlCMQCIKDg+Pi4rgStSEtKxSKsLAwAG3btr1w4YKxBszFKGPszTfZ1Kl1MXriRN134+IoRi2PYtQWpaamdurUCYCjo6NUKtVqtdz2kydPdu/eHYBQKJRIJGq12ijdffDBBwC6du1q6qfmNYRcLufz+XZ2dkePHr13PHl5eQkJCREREdzNVxw/P7/p06cnJSUplcoHNXvjxo2+ffsCaN++/cWLF404YEOMKpWsdev7x+i337ING5jxnopNHg/FqI1SKpUxMTFcWTp48ODz589z27mHIXOLKwcFBWVmZja6C71en5ycHBoailt31g8ZMsSIZVqjLVmyJDAwEICXl1dUVJRMJrt27dpd+yiVyu+++y46OrpVq1aGPHVwcBg5cuSVK1fu2vnatWu9e/cG0K1bt8LCQuOONjf39rNFf/6Z7dnDtm1jly7VbfnxR3bwIDt+nO3dy/77X+P2TBqKYtSmHThwoE2bNgCcnJykUqmhOvvtt9+6dOkCwM7OLi4uzlCuNpBWq/3mm2+CgoK49PH394+Ojvbz8wPg4uKyefPmBh4mm4hOp3v99dc7duxY/xA+PDx8zZo1mZmZ944tJydHKpVGRETY2dmJxeK7ivSCggLuz6pnz55FRUVm/Bx3+PRT9ssvlurc1lGM2jqFQhETE8OlSUREREFBAbe9srJSIpFwT10eNGjQuXPnGtKaRqNJTEzkzgwACAwMTEhIqKqququjkSNHXr582YSfqmHy8vJkMllkZKSDg4MhUn19fblDeIVCcdf+JSUlR44cqb8lPz+fi+MBAwbcvHnTjGO/w4ED7JNPLNU5oRgljDHG9u3bxx29urq6ymQyw/aDBw9y5apIJNq3b99DWlCr1YmJiVxdxp0iTEhIqK6uvmu3HTt2+Pj43NuRZVVWVqakpMTGxrZt2/auElUqlT5oluncuXOtW7cGEB4eXlZWZv5hc86cYc88wyQS9uOPlhqCraMYJXVu3Ljx/PPPcwkyatQowxlA7iyqt7f39evX7/uDNTU1MpmMS1sAnTp1kslktbW1D+ro+vXr48eP53YeO3bstQc0ayn3nWVq3759TExMUlJSeXk5t1tOTg73D8+wYcMMG4ltohgld0hKSuLuNXJ3d69fLd43Q1UqVUJCgmESJigoKDExsYEnUpOSkjw9PT0CAp4/fXqn5Q6HH6K0tHT79u0vvfSSr6+vIU+dnJxGjRr1zjvvcDdojR49mjtlQWwZxSi527Vr18aNG8elxqRJk+57yk+pVEqlUsO9nv37909KSnrciaPCwsJ3U1ODMzKCMzIW5uWVPbiAtTjDLBO3rh2fz7e3t3/++eeNdU0YsWo8RuvJkPv54osvXn/9dZVK5evru2XLlokTJ3Lbb968uWnTpo8//ph75nt4eLhEIhk7dmyjO/pBLo8vLKzS6TyFwkXt2j3l7m6cD2AaxcXFBw4c+OuvvyIjI4ODg2m1UAKAYpQ8UEFBQXR09C+//AIgKipq1apVn3/++YYNG7h1PcLDw1esWDFixIimd3RNo1lx6VKGSgUgwsNjcWCgK8UTsR4Uo+Rh9Hr9xo0bFy1aVFVV5ejoWFNTw+Pxxo0bt3Tp0pCQECN2xIBdJSUfFRZW6/XednZL2rXrIRJdVqu577ZzcPCyszNid4QYEcUoebQLFy7MmzevR48e165dW7x4seG6eqMrqKlZfulSdmUlDxjv41OsVge5uAAY6ubWXSQyUaeENBHFKGle9MC3xcV75fJILy8w9qKfn6VHRMgjUIyS5kjH2M6Skp8VCq4InRMQ4MintXFJM0Un8klzJODxAPQSiUZ7egKwr7fONCHNDcUoab587Oy60ilR0uzRgRIhhDQJnRslzZRSq2WAO11ASpo9ilFCCGkSOqgnhJAmoRglhJAmoRglhJAmoRglhJAmoRglhJAm+X8U1V9jMIYuMgAAAjB6VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHu/b+09BiDgAWJGBgiQB2IlIG5gZEvQANLMLGwJFiCakQUhAKUVDJBoJgSNrg7TIFwmYlGBoRRdhlNBAeR+KMWuABFmZodoQNAQCSYMCQ4FkH//M8JoAQWQOCsLNwNHAoNgBhODuAIjUwYTo3gCE3MCE68CM2cGE7NEAgsrAysbA5scAztHBhO7cAK7mAKHCAMnVwKneAIXdwYTN08Cj0QGE4+kAi9fBhOvQAKfVAK/VAYTv3SCgHQGk6BQgqAog5BwBpOYHIOMHIOsHIMICysjEzOnOBu7sJAgAwcbFzePBDMnG58Uv7QArzgsghjkG6S793eYX9gP4nhwstvf/c1gD2Jz32FwaM81BbNzt2s5RKqpgNXYzvI/MLt0ogOI/bYn7MAqbWcw+3PFtAMeAZJgNkNq9oEfqjvA6tkZRA+k3/MAs6N+nLIXFbsOZvO++2Hfd8DjAIituDbCYW5JMpht+KXPQfOzApi9RU3PIYyBCWI+T7tDjyQrmM0c1+KgsHQqmB3255u9WE8wmP2QYeb+wNvuYL2ZT5UObN5WCGZvCC860HHJGswO5+U7cFreDOyvzaU2ttX7a8Hii7PnHnDbLQF226GdbXYdjJVg9pGyZgfv6nYw245/r4PFcog5HpvmOjTsiwTbe+WEhkOrxBQwm0s15IBmhRfYfMFLJw9cZ2sEs70/zTzwxikNzBYDAFHjlN45N0kPAAACMnpUWHRNT0wgcmRraXQgMjAyMC4wOS4xAAB4nJ1WS27cMAzd+xS6wAgkRVHissj0AxRJgBToHbrqprl/qc/IHiQBYg4MDJ9pPvMvy+vr3/hlC+33cv35519YP7puW0gYEocA716qGn4TADT7C0aoUockJKVxQDQthIfwEcXx2oZFppKnBKn6WCgCNr+bbYHq9IWiSGksF4jCSC6WS4rEIw6OmbN4WVKmHlGKwJp9LGzZoDRiS5qdLClKqTAqbaH5snsxD6jiyG6p7MtLwJhrLrPrKrCXRZnriA2TOLvOalR7fY0lZwYfC0eWkkaGMrJ7AgohzllImLy+EMHsFyjqnCNuOc1DkiL+GpHKzDNkH4t1CWpOs9JEvuy2yvCNpRRnvzTbKjL4NLF7jgh1Tk9BPObl25m9CywwvFK567rPs9h+UdS5MbPKcaafzvhCkuZm0ELFx2JdB5VGzcGWhI8lR4WxpVqNCL2+KPWNab3LcwOfZ7HzKPXN0OZo8p1maSfJ2ipFQQ8sz29Z8AMWsRkUHXMJcOfLCRaO1Yo0bKvenWq/3rK88yGydW4db+gAjY5uoJ2YU2P30tLQUZM68wK4Aw4Iy4YD5aUxSRYwqSxQ2jfTDdTuG90AwUHTumACDbRs7I14BLujdrt9gww2k3ARmNR8owWWbxYM7hoDy1G7TTuQDmiBujSlg6mpAVeuDRAtoD248ZhFtueA9AAS7OAxhIcf37uNPWNTGpra/pvm69N1+w9/eaUC90aVpwAAAXh6VFh0U01JTEVTIHJka2l0IDIwMjAuMDkuMQAAeJwlkjtuIzEQRK+yoQRQRP8/cCjAoTfY0HA0uU7gw281hQGImQJfdbE4z+fz3+377+Pn/l6/Lr5un/fr9njJhfXS64VH73iBcN2+7i98zJaL//zeHrrFNHvZdvPg9QFFXdSXbrJ2g2I7SSSWbG13OUoxlS7a1W3eb4wtA1I2VQek2EpRvXgTFb255tZeD9reEVQHjCyy9eBtWjEgBkmxzrYsC7OjCbcff2YThQTfAjtkSARS0JZQ1hiyU6JGckkrB+ikZQBlE6tN+qRKOkoKM+OEpCy5PmyLkOoI2WOD5FLEaMXQhY+AOVYoLjKMxyMUI0eQbIRhIO0FRMnfcyPSfMKBEJ4tXp7nAEWIPYxNi2gF9ok5oMtnj253HV/bFqm8UImzFcrxjcr5KK1CJy7uBzGnIy/MnLbQn9qxFsEMVEMWxHTMG4fh0zN+hCF1Z067c0M593LcLWXdf/8DMjWCK33TS9MAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f0bde24c0d0>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f581b51d990>"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11168,17 +11277,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvigqKuIubqCiZFpiae4les1rJSV6s7BuGm6Ja3fQFnO5inVLql8ZZiqaaWTmEm6EC4hpICKKigwzw8DADDPz/P44OJIrwswchvm+X718zRzOPM8zph+/5zznPEfAGAMhhJD6EvI9AEIIsW0Uo4QQ0iAUo4QQ0iAUo4QQ0iAUo4QQ0iAUo4TcceEClMqa1xcvQqfjdTTERlCMEnLHtGl47bWa1//6F4qLeR0NsRFivgdASOOi1+PHHzFiBABUV6O4GOXl0OuhVsNgQFkZjEaoVACg1eZoNEeUSiVjjPtVpVIZjcaysjKDwTBr1qwePXq4ubnx+3WIFVCMEvI3K1bgxRfx1FMAsHcvXn/9gXsOHlzy22/TH/TTzMzMfv36/d///Z8FxkgaF4pRQv6mWTPExGDFCgCQSuHnB6kUIhHc3SEUwsMDAgE8PQGgUyf3Dh1iPTw8hEIh96u7u7tIJJJKpUqlcs6cOd98883kyZOfe+45fr8RsTQB3QxKAKSnpy9cuDAqKmr+/Pl8j4VPTz6J7dvh4YGBA1Faiv370bJlPZtauXJlfHx8SEhIVlaWs7OzWYdJGheaYiIAcPny5QMHDmRnZ/M9kEZBLMYnnyA3t0GN/Pvf/+7Zs2dubu77779vpnGRRopilABAaWkpAB8fH74HwqcDBzBhAtzdAaBvXxw5Aj+/+rSzd+9eo9EoFouTkpKEQmFiYuL58+fNO1TSqFCMEgCQy+UAvL29+R4IbwwGzJyJN9/Erl01W/r3h5PTY7czbdq04cOHJyUlAejbt+9rr72m0+lmzJhBZ8+aMIpRAtyuRu05Rr/4AufPo21bjBzZoHa4CaW5c+cWFRUBWLlyZfPmzQ8dOvTll1+aZZykEaIYJcDtatRuD+qrqrB0KQC8/z4cHRvU1Lhx40aPHl1WVvbOO+8A8PDwWLVqFYANG47K5WYYKmmEKEYJYPfV6Jo1KCxEjx6YMAEAjMYGtbZ27Vo3N7ctW7b8+OOPACZPnhwbe/yPPza++645xkoaH4pRAth3NapUIjERAFauhFAIgwF9+yI+HhUV9WwwKCho8eLFAGbNmlVZqQUwZ05fsRhffIEDB8w1atKIUIwSwL5n6mUylJZi0CA88wwAJCfjjz+wdSscHOrf5qxZs4YMednX9/CKFU4AQkIwbx4Yw7/+Ba3WTOMmjQZdfk8AwNvbW6FQyOVyezuuLypC+/aorER6OiIiUFWFjh1x5Qq++QaTJjWo5ZMnEREBsRinTqFLF+h06NkT589jxQrY9y0OTRBVowQGg0GlUgmFQk/uJkd7snHjMbGYvfACIiIAYO1aXLmC7t0xcWJDW+7TB7Gx0OkwYwYYg6MjNm6EQIDly5GX1/CBk0aEqlECuVzu6+vr4+NTUlLC91is6uLFi127dvXyCjlyJKNDB1elEiEhkMuxdy+efdYM7ZeVoXNnFBXh888xdSoAvPIKkpPxzDPYt88M7ZNGgqpRYr/X3s+fP1+v148b92SHDq4ANm26pFRi8GDzZCgAd3d88AEAzJ6NW7cA4MMP4eeHn3/Gd9+ZpwvSGFCMEjudpj958uQPP/zg4uLy3nvvAbh+/fqSJaHBweNWrao0Yy+TJuHZZ+HkVHMg7+MDmQyurigrM2MnhGcUo8ROLxqdN28eY2zWrFktW7YEsGTJEo1G0727KDzcxbwdff45zp+vOfcKYOpUpKfj119RWgoACgUWLzZvh8TaKEaJPVaj+/bt279/v6en55w5cwD89ddfn3/+uUgkWrZsmdn7CgyEh8edtwIBPDyQloa5cwGgshIHD5q9T2JVFKPE7i4aZYxxy6rOnz+fq8EXLFhQXV0dExPTuXNn64yhb18UFSE93Tq9EcuiGCV2d1C/ZcuWzMzMwMDAmTNnAsjIyPj++++dnZ25k6RW8/HHmDULer01+yQWQQ8RIXY3U797924ACQkJEokEQGVlZceOHUeNGtWqVStrDqN9ewwfjg0brNknsQiKUWJ350b9/PwAlJeXc28HDhyYlZWl4+OZ9PPmITwc/v7W75mYEx3UE7s7qB82bBiAxYsXX716ldsiFou5ytQ6BAKEhACAiws++AAdOlitZ2IRFKPE7qrRYcOGjR8/Xq1Wz5o1y/q9V1ZiyBA4OaGqCgCGD0dSkvVHQcyJYtSuabXaTZs25eXl+fj42E81CmDt2rWenp4//PBDamqqlbteswa5uUhLa+j60KTxoBi1U2q1OjExMSgoaPr06SqVav369W3btuV7UNbTrFmzpUuXAnjzzTdNJ0mtQKnEypUAsGoVhPSXr8lgxM6oVCqZTGaqPXv27JmSkmI0Gvkel7UZDIaIiAgAs2fPtlqn777LADZokNU6JNZAKzzZkZKSknXr1n3yySdKpRJAZGRkfHz8qFGj+B4Xb86ePRsWFgbgxIkTvXr1snR3d61tSpoOvnOcWMPNmzfj4+NNk9GRkZG//PIL34NqFLhZpj59+hgMBkv39dprDGDR0Zbuh1gbVaNNXEFBwUcfffTpp59WVlYKBIIRI0YsXLiwX79+fI+rsVCr1V26dLl69eqGDRtmzJhhuY4uXkTXrmAMWVmw1h2nxFr4znFiKXl5eXFxcU5OTgCEQuHIkSMzMjL4HlRjtG3bNgDu7u7Xrl2zXC/PP88ANn265XogvKEYbYKys7OnTJkiFou5AI2Ojs7JyeF7UI3a6NGjAUyaNMlC7R8/frxr16n9+sktGdSENxSjTcrp06enTJkiEokAODo6Tpky5eLFi3wPygYUFBS4ubkB+PHHHy3R/tNPP43bK5ySpoditIk4duzY8OHDuRM1Li4ucXFxhYWFfA/KlqxcuRJASEiIRqMxb8s//fQTAC8vL7lcbt6WSSNBU0xNQXFx8dKlS9evX+/m5hYTExMfHx8YGMj3oGyMXq/v06fP6dOnFy5ceNfizXv27Ll69arBYCgrKzMajSqVijHGXTSmUCgAqFQqo9FYVlZmMBjUanVmZqarqyv3WcZYeHh4ZmbmqlWrZs+ebf3vRayB5xgn5pCcnAygZ8+eVO80xPHjx4VCoaOj47lz52pvf9xLSktKSkyf/eabbwC0aNGioqLC6l+IWAktlNcUcGuLDB482K7uize7vn37Tps2LSkpacaMGQcPHhQIBNz2UaNG9enTRygUenh4CAQCT09PAF5eXgA8PDyEQqG7u7tIJJJKpWKx2M3NjdsBQHV19aJFiwAsXbrUmitIESujGG0K7G2lO8tJTEzctWvX4cOHk5OTX3nlFW7jkiVL6tfapk2bcnNzO3bs+NJLL5ltiKTxoRhtCuxtpTvL8fDwWLVq1eTJk2fPnj1ixAhugef7Mp0J1ev15eXl1dXVFRUVOp1Oo9FotdqqqiqlUrl48WIAMpmMu/iMNFX0f7cpoGrUjF588cXNmzenpaWFh4eHhIQ8aEKpLk316tWrd+/eY8aMseyICd8oRpsCqkbNa/z48enp6VeuXLly5cqD9jGdCXVwcHB1dXV0dJRIJE5OTs7Ozi4uLk5OThKJJCIiYurUqdYcOeEFxWhTYG9PSLYog8GwZs2aioqKmTNnjhs3rvaEkqenp0Ag4CaU+B4maUQoRpsCe3u0p0V99dVX586da9OmzYcffsitSEDIw9EC3E0BVaPmotPpuFXxly1bRhlK6oiqUZvHWPVvvzXT6ztwd4WThli3bl1+fn5oaOiLL77I91iIzaAYtXl6vZyxv5ydA0yXi5P64Z5PBUAmkwnpSUmkzujPis3T6+UARCI6om+oxMTE4uLigQMHPvfcc3yPhdgSilGbZzCUAhCLaX6pQYqLi9esWQNAJpPxPRZiYyhGbR5XjYrFVI02yOLFi9Vq9dixYwcMGMD3WIiNoRi1eXp9KQCRiKrR+svPz//f//4nEomWL1/O91iI7aEYtXkGA1WjDTVv3jydTvfyyy937dqV77EQ20MxavO4apTOjdbbmTNntm7d6uzsnJCQwPdYiE2iC574o9dj924UFKBrV0RFNaAZLkapGq2nd99912g0vvHGG0FBQXyPhdgkeogITwwGPPssnngC4eHYvRsGA+LjsWcPPDzw8suP1VJJyWdq9X5f3xlS6SALDbYJO3jw4ODBgz08PPLy8ug2MFI/VI3yZNcutG6NxYsBYORI9O8PrRZTp+Ixr/quqjpfVvaLXn+rvPw3itHHxRibO3cugPj4eMpQUm8Uozw5dw5hYXfehocjOxsDB8LHB97ef/vV27t8RKDR11Uk8hGLvcViX5HIw/S5goLYli1XSSRhOt0Dl3SrUVUFpRJKJRQKKJUoLUVGBsaPR2QkqquRn49mzeDubplv20ht27bt2LFjzZs3j4uL43ssxIZRjPJEKkV5+Z235eVgDAoFFIp7973Wv3u54qzprUAg4iLV1zdWIBBVVp5zde3r5NROo8ksK/vFYFCa/tPrFQaD0v+Dq77fagXa6vsM49NP8eGH+PRTRETgzz/RtSs++giXLgFA27Zo0mu2GwwG7kFJCQkJpgd5ElIPdG6UJ9nZeO01HDoER0coFOjfH8eOwWiEXI7S0ppfb7+4OlNfKco3GEr1+hK9vtRgUHFtBAYu8/aeWFS0SKPJbN58kUZz6ubND+/qR6xAj6EPHUmrVjhzBl5eABAdjX/+EzodAIwcCReX+35iQX7+da3WWSgEsKRtWz8Hh4b9XvBj06ZN06dPb9++/blz5xxs8yuQRqIplxuNWrdumDoVTz6J4GDk5eHjj8E9TvJ+a4a2/PtbxvQGQ6leLxeJvB0cAtq2/Vavv5WT06N58/ckkp6VldmM6U07i1WPGklISE2GAhgzBkeP4lF3Q+qMxrmtW3d4QMjahMrKSu5h9CtWrKAMJQ1EMcqf6dMRGwuF4r7R+RACgVgs9heL/QFoNBkuLr0Y0wkEDr6+r/r5/cto1Gg0pyoqTmg0JyoqTlR7X6r2h0Pxg5urnYYODjWl6KNkl5crqqslIlGo7RwOq1Sq3NzcvLy8vLy81NTUq1ev9u7de/z48XyPi9g8ilFeCQSPm6F3Ual+LCpaBIjatPlcIHAEIBRK3Nwi3dwiuR30+hL97v0OX6cjNxcnTqCk5O4m/voL1dXgKrIjRxARUZd+L1VVqQwGH7G4ccaoQqG4dD+19/Hx8enXrx+tLkgajs6N2raKipNXr86WSp8MDFxWpw9cuoQTJ2r+O3MGs2fDwwNpaYiOxrlzOHMGe/Y8cmZpTl7etMDAxnBQr9frCwsL8/LyTGUmp6Ki4t6dJRJJu9sqKyv/+9//NmvW7NKlSy6N4IsQm0bVqG3T6QrKyw85ODzwcep3Cw5GcDD+8Q8AYAxcLfbsszh1CiNGQCaDLTysLSMj47333svLy7t8+XJ19X2uQPDx8Wn3dyEhIc2bN6+9z8mTJ0+ePPn555/PnDnTWgMnTRNVo7bt1q2kK1dm+PrGtm6dZLVOf1Uqe7i5+fB0OdSxY8cWLVqUlpbGvfXy8gqupUuXLt26deMe5/lw27dvf/7551u1apWbm+vo6GjhUZOmjKpR28bLms293dyGnjnTytn5Bz7WQ/r999/T0tKee+65lStXtmvXztnZ+eH7KxSK2sf7L7zwAre4/dixY0NDQ7Oysr766qtXX33VKmMnTRPFqG3jZV0SlV7PAL6mZrKysgCMHj363kXt6jKz1KxZMy5GBQLBvHnzXnzxxf/85z8vv/yyuEnfa0Asiv7o2LbbD2KyajWq0usBePB0FpWL0dDQUO5tRkbGihUruEpTo9Hcu7+rq2vtM6T9+/c3/WjChAlLliy5cOHCd999N3nyZOuMnzQ9FKO27fZBvXWrUYMBgAcf5Zter8/JyREIBN26deO2aLXaHTt2cK/vOk/KadOmzYMe8ykSieLj42NiYlasWDFp0iR6GiipH4pR21Za2hHobzC0fPSu5sNVo+58xOjFixerqqqCg4Pdb6+i0r1795SUFK7Y9PDwePjH7/XPf/5z2bJl58+f3759+wsvvGDu8RK7QP/82rZXXkns2zf95s2wR+9qPjUH9XzE6NmzZwF0797dtEUqlUZHR/fu3bseGQrAwcFhzpw5AJYvX05XrZD6oRi1bXI5cP8b8S2o5qCej3Oj3InR2jHacDExMS1atDh9+vSePXvM2CyxHxSjto1bV8/KMVrGdzVqml8yCycnp3feeQcAt1gJIY+LYtSGqdXQ6SCVwsoXj/N4blQsfr1Xr9mhoT3N2+z06dP9/f2PHz++f/9+87ZM7AHFqA3j5YgegP7QofY5Oe5KpZX7Vamwc+fwP/9cFRISYt6WJRLJW2+9BWDFihXmbZnYA4pRG1ZaCgDWf4bQ/jVrtrz0kuP9Fuq3qLNnwRi6dbPIff8zZ8708vI6cODAkSNHzN86adIoRm0YX9WoXC4HYP1nwJ09CwBmnV66w93dnXsi0/vvv2+RDkjTRTFqG3JzYTTWvC4sREUF/vgDYWE4eBDLl+PcOasOprS0FIC31fM7KwsAzDq99DdxcXFSqfSnn346efKkpfogTRHFqG0YPx5qdc3rOXOQmYnwcGzdiiefRHg4oqOtNxKdTldeXu7g4ODm5ma9XgHcrkYtF6Pe3t6vv/46qCAlj4li1FZ164ZPP8XNm9bu13REb+V14xmrKbotF6MA/v3vf0skkp07d3JXVhFSFxSjNmP9enz0ET76CBcuAICTExYuxOzZ1h4Gd0Rv/ROj+fkoK0NgIPzqvER1XRiNxri4uH379nFv/f39p02bxhhbtGiRwWAwZ0+k6aIYtRmdOqFLF3TpAtNNj2PHQqHAwYNWHQZXjVr/xKgl5pcMBkNMTMzatWsnT56svn3SZMyYMQ4ODunp6QEBARMmTNi0adP169fN2StpcihGbcaQIRg2DMOGoVmzOxs/+QTz5wPA8eP47DNY4aZwvqpRuRxSKW6v62QGer3+lVdeSU5OdnV13bJli1QqBZCRkTF+/Pjq6urq6mq5XL5169bp06e3atVqwIABy5cvz8zMpPvuyX0wYgt69GBKZc3riRPZoUMsLKzm7eLFrFMn1rEjA9jw4ezqVQsOIzMzMzIy0tPTs23btteuXbNgT7Xs2MEOHWKMMaORbd3KiorM0KZWqx03bhwADw+P33//ndt45MgRbn2TkSNHVlZWXrx48eOPPx46dKiTk5Pp70uzZs3eeWfD1q13/ncQQjFqG06eZHp9zetz55hSyY4fr3lbWcnS01lKCvP1ZQDz8GBJSeYfwIEDB6KiorgocXV1BeDl5fX111+bv6d7TJjAgoOZQsEYY5Mn3/ni9VZRUfHMM89wX+H47eZ+++03riCdOHGiTqervb9Go0lLS4uLiwsKCgIwaNABgIlELCyMJSSwjAxmNN7Z+do1VlhY87qoiMnlDR0tafwoRpuOGzfY2LEMYAB77jlmrmLx8OHDQ4YM4QJUKpXGxcWdPXt2zJgx3JYRI0ZYuiydMIEtWMBef50xc8RoeXk593UCAgLOnDnDbdyzZw/3mOXJkydXV1c/5ONnz55du1Y+aBATi2t+qwHWujWbMYOlprKKCrZwIQsKYmo1Y4wtXsys8g8N4RnFaFOTksK8vRnA/PzY99/Xvx2j0ZiamtqvXz8uLn18fBISEkpLS2t1lOLl5QXAz8/v+4b09CgTJrCsLPbUU+z48YbGqEKh4B4i0rx58+zsbG5jamoqd9g+ffp0g8FQ56ZYSgp75RUWEHAnT11c2DvvsHHj2OzZjFGM2g2K0SaooIBFRdX8xZ4xo0z+mAeWBoMhNTU1LKxmKWg/P7+EhATl/c4FFhQUmI70o6OjS0pKzPQNGGPMaGTbt7PvvquJ0exsNmAAmzSJHT/Ovv2W/f2wu05KS0v79u0LoHXr1rm5udzGb7/91sHBAcDs2bONtQ/OH0d2NpPJWFQUCwtjCxeybdtYZCQ7c4Zi1F5QjDZNRiNLSmLu7qxHj7iAgIAdO3bU5VMGgyElJaVTp05cMrZq1Wr16tUajca0w+nTp2/duvX3joxJSUncHU3NmjXbuXNnwwdvMLDUVNa7NwNY8+bshRdYVhZjjM2Zw7y8WGIiA1hQEEtKunO++JFu3LjBrVLaoUOHwtsnL7/66iuRSAQgPj6+4cNmjGm1bOFC9sMP7I8/2JNPUozaC4rRpiwvr/SJJ57gMvHVV19VqVQP2lOr1SYnJ7dv357buU2bNqtXr66srDTtcOrUqejoaIFAMHfu3Hs/funSpUGDBpnK0trH/o9Fp2NffME6dKgppYOC2Lp17OWXWU4OY4yp1axTJ7ZhA+vcuWaHXr3Y3r2PbvbKlSvcV+vcubPpTO6GDRu4Z9gtWbKkfqO9Ly5GGWNvvMFCQylG7QLFaBPHVYsSiQRAUFDQL7/8ctcOVVVVSUlJLVvWPBSvXbt2SUlJtadZDh06xM1rc3P077333iM7at269f79+x9rnFotS05mISE1+di2LVu9mtWK8b8xGFhKCmvbtmbnAQPY4cMPbDk/P79du3YAevXqZSqlV65cCUAgEHz88cePNc5HMsWoSsUCAylG7QLFqF3Iycnp06cPFxyxsbFqtZoxplarV69e3bx5cy4iQ0NDk5OT9bWOkw8fPjxy5Ejup25ubnFxcUWPumjz3Llz93b0cBUVFZs2HQ4MrMnELl3Y11/X6Whdq2VJSczfv+aDUVHs7Nn77Hb48GGJRNK/f38Fd80UYzKZjBvhunXrHt3NY7p2rebarMJC9tlndMGTXaAYtRfV1dXLli1zdHQEEBwc/Oqrr5pu6OzXr19qamrtCZa0tLSIiAjup+7u7vHx8XWfp6qurpbJZFxHbdu2PXjw4IP2NOW4SOTYpo2ue3eWnPwYpztvN8JkMiaVMoA99dS+6Ojo/Pz8u/Y5evSoKdAXLlwIQCQSbd68+fF6ehyVlczJiQmFrL6nN4gtoRi1L1lZWb179zZdQh8ZGZmammr6KTdHHx4e/sg5+kc6e/Zsr169AAiFwri4uKqqqto/lcvlCQkJ3PVSACIiIvbty67vPDljjF27xt58UyeVBgCQSCRz58411Z4mRqNx1qxZABwdHbdu3Vr/zurmiScYwHbtsnQ/hH8Uo3ZHq9Vyd8SnpKSYNnJz9J07d+ZyLSAgQCaTVVRUNKQjnU4nk8m4y4m6dOly8uRJxlhxcXFCQoKnpyfX0V053kAXLlzg5sG4O5RkMpnpMgO9Xh8TEwPAyclp+/bt5urxIRYsYEDNBaSkaaMYtUdcKWo6zlUoFMHBwVyutW3bduPGjXcVjw1x9OjRjh07AnBwcIiMjOTmoAAMGzbsyJEj5uqlthMnTphuu2rRokVSUlJVVdVLL73EFao///yzJTrlnDzJ/vOfmvvHfv6ZASw83HK9kcaCYtTuaLVa7sC29sZnn302ODj4rjl6c6msrIyPjxcIBC1atBAIBCNHjjze8BvjH2Xfvn3c6QsA3IIj7u7uhx8yo28Oo0YxgCUnM8ZYRQVzdGQiES1i0vRRjNqdoqIi7m7I2huLi4vrfh9k/URGRgKwxOT4gxiNxpSUlHbt2rVs2VIqlR49etTSPX7wAQNYTEzN2/79GcD27LF0t4RntN6o3bnvust+fn7cteiWo9frAZjuMbUCgUAQHR19+vTpkpKS8vJysz/d/l6DBwO4s5A2d0eCldfVJtZHMWp3rLbuck5OzrZt2y5wzzzh73mibm5uERERjDErPIC+Z094eiIvD4WFAMWo3aAYtTtWewrIzp07x48fn5ycXLtf6y+bD4C7UfWg5fNMJMKAAQBw+DAAREbC0REqVVV5eaWluyY8ohi1O1aLs9rlp9FoVCqVQqHQdKmTNVktRgEMGgShEJmZagBSKQYMGHP+vEt6+mErdE34QjFqd6x2cF277FUqlUaj0dPTk1tRycr69+/v7Ox85swZpVJp6b6efjpPKm2ze3cf7m14eAcAhw4dsnS/hEcUo3bHaudGa5e9fD1PlOPs7BweHm40Gq1yerS10Vh64cIF7ooIrhD+7bffLN0v4RHFqN2xWqLVLnt5PDHKGTx4MKxyXC8Wi7kF9rnIHjhwoEgkOnnypEajsXTXhC8Uo3aHl2qUr2l6E2tWhbVPxXp4ePTo0UOn0x07dswKXRNeUIzaHStXo7UP6nmsRgcMGODo6Hjq1CmVSmXpvu6a0bLmBBfhBcWo3bFaoikUCgDcMk68V6MSiSQsLMxgMKSnp1u6rz59+ri6uubk5BQXF4Ni1A5QjNod6yRaWVmZTqeTSqXcwqNWO5PwEFaLM0dHx/fff3/Lli3cEjADBw4UCoXHjh2rqqqydNeEFxSjdsc6MXpXbvI7U8+xZlUYFxc3YcIELka9vb0DAwMNBsPo0aM3b9588+ZNKwyAWJOY7wEQq6qoqKiqqpJIJC4uLhbt6K7cbAzV6BNPPCEWizMyMtRqtVQqtU6njLG33nrr6tWr7u7uaWlpaWlpALp06TJq1KioqKjBgweLxfR30OZRNWpfrHztfaOqRt3c3Hr16qXX6602ac4Ye/PNN9esWePo6JiYmLh+/foRI0ZIJJKcnJzExMShQ4cGBgZOmTLl22+3lJZaZ0TEIihG7Qsvd4Jas9+Hs+ZxvcFgmDp16vr16yUSya5du2bMmPH666/v3r1bLpenpaXFx8d37tz51q1bX3/99eLFP/j7Izwcc+fiyBEwZoXREXOiGLUv9z245iaUzeuu3OR9pp5jtRjV6XT/+Mc/kpOTXV1dd+3aZXpCNQBnZ+eoqCiZTJaTk/Pnn39+9NFHgwfPFIvxxx9ITMTAgWjZEtOm4YcfoFYDwK+/Ijy85vWhQ1iyBG+9hTNnalpbswbbt1v625BHoBi1L/ceXF++fLl9+/bTp08vLy83Y0eNsxrl7ik6ceKERe8p0mq1EydO/P777z09PdPS0p5++ukH7SQovisAAAc2SURBVNmxY8e33347KWlQSQm2b8e0aWjZEkVF+OwzvPACfH0xZAiysqBWIyEBADQayOW4cQOmOf/SUpSVWe6rkDqhGLUvXLpxD33jpKenV1ZWbtq0qXfv3ma8pnLgwIELFizgqj+9Xq9Wq8Visbu7u7nar5/73lNUWFgYERGxdOnSjIwMo9HYwC40Gs2oUaN27Njh7e39888/czeGPpKbG8aOxaZNKCxEXh5Wr0ZUFBjDr79CIsHYsTh1CqdO3dn/+nXk5yM/H5Zfa4XUAc+r7xPrunDhwrBhw0QiUXx8vE6n4zZmZWWZHoYcGxvbwAeC3ou7xMff39+8zdbP22+/DWDRokWmLRs3bjT9dfD19Y2Ojk5OTi6t1wPm1Wr1U089BSAgIODs2bMNHGppKUtNZampLD6enT7NIiPZnj3szTfZxIls7FgWG8tiY1lYGNu8uYH9kIaiGLU7cXFxXDXat2/fnJwcbuN9H4ZsLjk5OQA6depkxjbrbceOHQAGDRpk2qLRaLg5H+4JphyRSBQWFpaQkMCVqHVpWaFQREREAGjVqtXFixfNNWAuRhljb73FJk2qidFjx2p+mpBAMco/ilF7dPjw4Xbt2gFwdnaWyWR6vZ7bfvz48U6dOgEQi8Xx8fFardYs3X344YcAOnToYOmn5tWFXC4XCoUODg6HDh26dzx5eXmrV6+Oioribr7iBAQETJkyJSUlRaVSPajZmzdv9ujRA0CbNm1yc3PNOGBTjKpUrEWL+8fod9+xtWuZ+Z6KTR4PxaidUqlUsbGxXFnav3//CxcucNu5hyFziyuHhoZmZmbWuwuj0Ziamtq3b1/cvrN+wIABZizT6m3BggVBQUEAfHx8oqOjk5KSrl+/ftc+KpXq+++/j4mJad68uSlPnZychg4devXq1bt2vn79erdu3QB07NixsLDQvKPNybnzbNFffmE7d7LNm9nlyzVbfvqJ7dvHjh5lu3ax//3PvD2TuqIYtWt79+5t2bIlABcXF5lMZqrOfv/99/bt2wNwcHBISEgwlat1pNfrv/3229DQUC59mjVrFhMTExAQAMDNzW3Dhg11PEy2EIPB8MYbbwQHB9c+hI+MjFyxYkVmZua9Y8vOzpbJZFFRUQ4ODlKp9K4ivaCggPu96tKlS1FRkRW/x9989hn79Ve+Ord3FKP2TqFQxMbGcmkSFRVVUFDAba+oqIiPj+eeutyvX7/z58/XpTWdTpecnMydGQAQFBS0evVqjUZzV0dDhw69cuWKBb9V3eTl5SUlJY0cOdLJyckUqf7+/twhvEKhuGv/kpKSgwcP1t6Sn5/PxXHv3r1v3bplxbH/zd697L//5atzQjFKGGOM7d69mzt6dXd3T0pKMm3ft28fV65KJJLdu3c/pAWtVpucnMzVZdwpwtWrV1dWVt6129atW/38/O7tiF8VFRVpaWlxcXGtWrW6q0SVyWQPmmU6f/58ixYtAERGRiqVSusPm3PmDHvmGRYfz376ia8h2DuKUVLj5s2bzz//PJcgw4YNM50B5M6i+vr63rhx474frKqqSkpK4tIWQLt27ZKSkqqrqx/U0Y0bN8aMGcPtPGrUqOsPaJYv951latOmTWxsbEpKSllZGbdbdnY29w/PoEGDTBuJfaIYJX+TkpLC3Wvk6elZu1q8b4aq1erVq1ebJmFCQ0OTk5PreCI1JSXF29vbKzDw+dOnt/F3OPwQpaWlW7Zseemll/z9/U156uLiMmzYsHfffZe7QWv48OHcKQtizyhGyd2uX78+evRoLjXGjx9/31N+KpVKJpOZ7vXs1atXSkrK404cFRYWvnf4cFhGRlhGxty8POWDC1jemWaZuHXthEKho6Pj888/b65rwohNEzBaT4bcz5dffvnGG2+o1Wp/f/+NGzeOGzeO237r1q3169d/8skn3DPfIyMj4+PjR40aVe+OfpTLEwsLNQaDt1g8r3Xrpzw9zfMFLKO4uHjv3r1//fXXyJEjw8LCaLVQAoBilDxQQUFBTEzMr7/+CiA6OnrZsmVffPHF2rVruXU9IiMjlyxZMmTIkIZ3dF2nW3L5coZaDSDKy2t+UJA7xROxHRSj5GGMRuO6devmzZun0WicnZ2rqqoEAsHo0aMXLlwYHh5uxo4YsL2k5OPCwkqj0dfBYUHr1p0lkitaLffT1k5OPg4OZuyOEDOiGCWPdvHixVmzZnXu3Pn69evz5883XVdvdgVVVYsvX86qqBAAY/z8irXaUDc3AAM9PDpJJBbqlJAGohgljYsR+K64eJdcPtLHB4y9GBDA94gIeQSKUdIYGRjbVlLyi0LBFaGvBwY6C2ltXNJI0Yl80hiJBAIAXSWS4d7eABxrrTNNSGNDMUoaLz8Hhw50SpQ0enSgRAghDULnRkkjpdLrGeBJF5CSRo9ilBBCGoQO6gkhpEEoRgkhpEEoRgkhpEEoRgkhpEEoRgkhpEH+H323hE1ui5UoAAADDnpUWHRyZGtpdFBLTCByZGtpdCAyMDIwLjA5LjEAAHicnZVLaNRAGMcnk91ks5vss/tud2OxpfVRs90+0XZjC3Wx0FoqrfUgAVEjpQfFSqUIFR8tWAqCClV6EhGEgqj4QOwG8eDjIkXoQS148OYLK1JQ0OSb9OAtnYGZ/DPM7z8z33yTfFuYX0ZmEc3KIFKyZq006wTDddSYT9a11WU+5M5czhpSZzXbrEZWWLPtK5L+nfXQlycm3wuNTCvXoVs8y6wZ5MEAr8Pg/wU0AM9S843Au5zzWLMCw9q8QgLgXieP8RoPI+o4ap7Ej6fdv9ICvIeabwVeoI5/E/Be+gRqBgMfvQGJgEi9AxIBiZbPkwzwU28gT1IgQG9A7kCQ3oCcQYg6BOQIwtQLaFDAIEJvQK5xmWMDAcumtPGuHJk/SonnSQrFHOM8huVj26BHIQcQd25ADsD+ivXkSA4maPl6sv/kejfA4DUDEv8U7QLy5DeQpubJZ6jcMe/B1v/wr30AvQq5QhXUPJk/45gP4i1WArntK9SvkABkHRv4kEdDIR2juMxgHTNxDbMalmRW0DGb0Fxu5OYQl0G8R8d8RONjsqcMCV5NiGten459oiYmdCwmZcmvYymo+VNaIKXjQFoLpnUcCmuhKApHdBzLoEy5i6nIoDKXm8GsEOf4SDiEPJzXJyZYgfOnAumgFGeQXbIT6YulqeY3JeulKPCFD79RwdK+90idHGkEPfJwkzpUvRHGtF3rNa6PXlIt/WV6wLi9uRP0ythVo7gnCRodGjZWqx7BeB5FjSPLRdD7V18VorEl0NLX1cKMUTQsvWF+nzp34iDo3M8ZtXZFBn2/uk4dQJj4i5PqdNINmj1wTpVvXgE98OdXITbdD/ojmi31vdsF7NFPlca9B8dA3xk8bkwtbgc9KPmN19km2Ne90R1t46XT0H9jeM7oepKAtT17fKF9ijkF+vnJs2r3+CTo9sBTteUW8SnenVMnFoZg3rcvatTzicugvVV7jdqx3eAfWnxpLHFnQHf/mDU+dxwGHfsHKpgyovtvGHoAAAIselRYdE1PTCByZGtpdCAyMDIwLjA5LjEAAHicnVZLjtswDN37FLqABZKiKHFZTPoBik6BFugduuqmc/+hPpEdoAViBkbCJ5ov/Nvy9vYnfthC+/y4ff39N6wP3bYtJAyJQ4B/XqoafhEANPsdI1SpQxKS0jggmhbCS/gfxfnahkWmkqcEqfpYKAI2v5ttger0haJIaSw7RGEkF8ueIvGIg2PmLF6WlKlHlCKwZh8LWzYojdiSZidLilIqjEpbaL7s7uYBVRzZLZV9eQkYc81ldl0F9rIocx2xYRJn11mNaq+vseTM4GPhyFLSyFBGdk9AIcQ5CwmT1xcimP0CRZ1zxC2neUhSxF8jUpl5huxjsS5BzWlWmsiX3VYZvrOU4uyXZltFBp8mds8Roc7pKYjnvHy6sneBBYZXKg9d9zyL7RdFnRszq5xn+vWKLyRpbgYtVHws1nVQadQcbEn4WHJUGFuq1YjQ64tS35jWuzw38HUWex6lvhnaHE2+yyztSbK2SlHQE8v351nEZlB0zCXAgy8XWDhWK9KwrfrwVPv5LIuVRPv3AGh0dAftiTk1dpaWhs4aOz4DPAAHhGXDgfLSmCQLmFQWKO2d6Q5q943ugOCkaV0wgQZaNvaPeAaHo3bc3kEGm0m4CExqvtECyzcLBg+NgeWoHdMBpANaoC5N6WBqasCVawNEC2gPbtxmkR05MImGDRqAQ/MthJcvn7tNu2G3Q1Pbb9N8fL1t73MopP0VNIAaAAABfXpUWHRTTUlMRVMgcmRraXQgMjAyMC4wOS4xAAB4nCWSvWrtMBCEXyWlDbLY/12RJnAgZW5xy5DK/XmCPHxmdTAIe9A3Oxr58Xh8///4+Dm+/10/52v9uvk+Ps/7uJ5yY731fuLREy8Q7uPrfOKjt9z89ntcOsU017Dp5sHjHYq6qA+dZMsNis0kkRgydbnLVoqpdNCstczXC2PLgJSLagWkmEpRa/AkKnpxi5eucdH0FUG1wcgiGxdP04oGMUiKtbdlWZhtTXj59mc2UUjwLbBNhkQgBU0JZY0mV0pUSy5p5QCdtAygTGK1Tp9USVtJYWackJQlx7tNEVJtIVfbILkUMVoxdOEtYI4ViosM4/YIxcgWJBfCMJDlBUTJX3Mj0rzDgRDuLV6e+wBFiN2MdYtoBfaJOaDLe49Od21fmxapPFCJsxXK8YnKeStLhXZc3A9idkdemNltoT+1bS2CGaiGLIhpmy8chnfP+BGa1JnZ7fYNZd/LdreUcf7+ATYPg2M70RQJAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f0bde42fdf0>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f5820d54170>"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11196,17 +11305,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVxU5f4H8M8sbAPDvomK+y5uIKJkWmJp4laiP/NaSYleLaybNm6Ja3fQFnJJx9stqW4ZZiqaaWSmGGoQKiCmSYgoKjIMw7DNMDPP74+DI+4IszDM9/3qxWvmcHieZ0w+fs95znkOjzEGQgghjcW39AAIIcS6UYwSQkiTUIwSQkiTUIwSQkiTUIwSQkiTUIwSctv58ygrq3t94QI0GouOhlgJilFCbps5E6+9Vvf6n/9EcbFFR0OshNDSAyCkedFq8cMPGDMGAGprUVyMigpotVCpoNOhvBx6PZRKAFCrc6uqjpWVlTHGuK9KpVKv15eXl+t0unnz5vXt29fFxcWyH4eYAcUoIXdYswYvvoinngKAAwcwZ84D9xw+vOTXX2c96LuZmZmDBg363//+Z4IxkuaFYpSQO/j7Izoaa9YAgFgMHx+IxRAI4OoKPh9ubuDx4O4OAN27u3btGuPm5sbn87mvrq6uAoFALBaXlZUtWLDg66+/njZt2nPPPWfZT0RMjUc3gxIAaWlpS5cujYiIWLx4saXHYklPPoldu+DmhqFDUVqKQ4fQpk0jm1q7dq1EIuncuXN2drajo6NRh0maF5piIgBw6dKlw4cP5+TkWHogzYJQiI8/xsWLTWrkX//6V79+/S5evPjee+8ZaVykmaIYJQBQWloKwMvLy9IDsaTDhzF5MlxdASA0FMeOwcenMe0cOHBAr9cLhUKZTMbn8+Pj48+dO2fcoZJmhWKUAIBcLgfg6elp6YFYjE6HuXPxxhvYu7duy+DBcHB47HZmzpw5evRomUwGIDQ09LXXXtNoNLNnz6azZy0YxSgBblWjthyjn3+Oc+fQoQMiI5vUDjehtHDhwqKiIgBr165t1arV0aNHv/jiC6OMkzRDFKMEuFWN2uxBfU0NVq4EgPfeg719k5qaOHHiuHHjysvL3377bQBubm7r1q0DsHnzcbncCEMlzRDFKAFsvhpdvx6FhejbF5MnA4Be36TWNmzY4OLisn379h9++AHAtGnTYmJO/vHHlnfeMcZYSfNDMUoA265Gy8oQHw8Aa9eCz4dOh9BQSCSorGxkg4GBgcuXLwcwb9686mo1gAULQoVCfP45Dh821qhJM0IxSgDbnqmXSlFaimHD8MwzAJCYiD/+wI4dsLNrfJvz5s0bMeJlb+/UNWscAHTujEWLwBj++U+o1UYaN2k26PJ7AgCenp4KhUIul9vacX1REbp0QXU10tIQFoaaGnTrhsuX8fXXmDq1SS2npyMsDEIhTp1Cz57QaNCvH86dw5o1sO1bHFogqkYJdDqdUqnk8/nu3E2OtmTLlhNCIXvhBYSFAcCGDbh8GX36YMqUprY8cCBiYqDRYPZsMAZ7e2zZAh4Pq1cjL6/pAyfNCFWjBHK53Nvb28vLq6SkxNJjMasLFy706tXLw6PzsWMZXbs6l5Whc2fI5ThwAM8+a4T2y8vRoweKivDZZ5gxAwBeeQWJiXjmGRw8aIT2STNB1Six3WvvFy9erNVqJ058smtXZwBbt/5dVobhw42ToQBcXfH++wAwfz5u3gSADz6Ajw9++gnffmucLkhzQDFKbHSaPj09/fvvv3dycnr33XcBXLt2bcWKoI4dJ65bV23EXqZOxbPPwsGh7kDeywtSKZydUV5uxE6IhVGMEhu9aHTRokWMsXnz5rVp0wbAihUrqqqq+vQRhIQ4Gbejzz7DuXN1514BzJiBtDT88gtKSwFAocDy5cbtkJgbxSixxWr04MGDhw4dcnd3X7BgAYC//vrrs88+EwgEq1atMnpfAQFwc7v9lseDmxtSUrBwIQBUV+PIEaP3ScyKYpTY3EWjjDFuWdXFixdzNfiSJUtqa2ujo6N79OhhnjGEhqKoCGlp5umNmBbFKLG5g/rt27dnZmYGBATMnTsXQEZGxnfffefo6MidJDWbjz7CvHnQas3ZJzEJeogIsbmZ+n379gGIi4sTiUQAqquru3XrNnbs2LZt25pzGF26YPRobN5szj6JSVCMEps7N+rj4wOgoqKCezt06NDs7GyNJZ5Jv2gRQkLg62v+nokx0UE9sbmD+lGjRgFYvnz5lStXuC1CoZCrTM2Dx0PnzgDg5IT330fXrmbrmZgExSixuWp01KhRkyZNUqlU8+bNM3/v1dUYMQIODqipAYDRoyGTmX8UxJgoRm2aWq3eunVrXl6el5eX7VSjADZs2ODu7v79998nJyebuev163HxIlJSmro+NGk+KEZtlEqlio+PDwwMnDVrllKp3LRpU4cOHSw9KPPx9/dfuXIlgDfeeMNwktQMysqwdi0ArFsHPv3ytRiM2BilUimVSg21Z79+/ZKSkvR6vaXHZW46nS4sLAzA/PnzzdbpO+8wgA0bZrYOiTnQCk82pKSkZOPGjR9//HFZWRmA8PBwiUQyduxYS4/LYrKysoKDgwH8/vvv/fv3N3V3d61tSloOS+c4MYcbN25IJBLDZHR4ePjPP/9s6UE1C9ws08CBA3U6nan7eu01BrCoKFP3Q8yNqtEWrqCg4MMPP/zPf/5TXV3N4/HGjBmzdOnSQYMGWXpczYVKperZs+eVK1c2b948e/Zs03V04QJ69QJjyM6Gue44JeZi6RwnppKXlxcbG+vg4ACAz+dHRkZmZGRYelDN0c6dOwG4urpevXrVdL08/zwD2KxZpuuBWAzFaAuUk5Mzffp0oVDIBWhUVFRubq6lB9WsjRs3DsDUqVNN1P7Jkyd79ZoxaJDclEFNLIZitEU5ffr09OnTBQIBAHt7++nTp1+4cMHSg7ICBQUFLi4uAH744QdTtP/000/j1gqnpOWhGG0hTpw4MXr0aO5EjZOTU2xsbGFhoaUHZU3Wrl0LoHPnzlVVVcZt+ccffwTg4eEhl8uN2zJpJmiKqSUoLi5euXLlpk2bXFxcoqOjJRJJQECApQdlZbRa7cCBA0+fPr106dK7Fm/ev3//lStXdDpdeXm5Xq9XKpWMMe6iMYVCAUCpVOr1+vLycp1Op1KpMjMznZ2duZ9ljIWEhGRmZq5bt27+/Pnm/1zEHCwc48QYEhMTAfTr14/qnaY4efIkn8+3t7c/e/Zs/e2Pe0lpSUmJ4We//vprAK1bt66srDT7ByJmQgvltQTc2iLDhw+3qfvijS40NHTmzJkymWz27NlHjhzh8Xjc9rFjxw4cOJDP57u5ufF4PHd3dwAeHh4A3Nzc+Hy+q6urQCAQi8VCodDFxYXbAUBtbe2yZcsArFy50pwrSBEzoxhtCWxtpTvTiY+P37t3b2pqamJi4iuvvMJtXLFiReNa27p168WLF7t16/bSSy8ZbYik+aEYbQlsbaU703Fzc1u3bt20adPmz58/ZswYboHn+zKcCdVqtRUVFbW1tZWVlRqNpqqqSq1W19TUlJWVLV++HIBUKuUuPiMtFf3fbQmoGjWiF198cdu2bSkpKSEhIZ07d37QhFJDmurfv/+AAQPGjx9v2hETS6MYbQmoGjWuSZMmpaWlXb58+fLlyw/ax3Am1M7OztnZ2d7eXiQSOTg4ODo6Ojk5OTg4iESisLCwGTNmmHPkxCIoRlsCW3tCsknpdLr169dXVlbOnTt34sSJ9SeU3N3deTweN6Fk6WGSZoRitCWwtUd7mtSXX3559uzZ9u3bf/DBB9yKBIQ8HC3A3RJQNWosGo2GWxV/1apVlKGkgagatXqM1f76q79W25W7K5w0xcaNG/Pz84OCgl588UVLj4VYDYpRq6fVyhn7y9HRz3C5OGkc7vlUAKRSKZ+elEQajP6uWD2tVg5AIKAj+qaKj48vLi4eOnToc889Z+mxEGtCMWr1dLpSAEIhzS81SXFx8fr16wFIpVJLj4VYGYpRq8dVo0IhVaNNsnz5cpVKNWHChCFDhlh6LMTKUIxaPa22FIBAQNVo4+Xn5//3v/8VCASrV6+29FiI9aEYtXo6HVWjTbVo0SKNRvPyyy/36tXL0mMh1odi1Opx1SidG220M2fO7Nixw9HRMS4uztJjIVaJLniyHK0W+/ahoAC9eiEiognNcDFK1WgjvfPOO3q9/vXXXw8MDLT0WIhVooeIWIhOh2efxRNPICQE+/ZBp4NEgv374eaGl19+rJZKSj5VqQ55e88Wi4eZaLAt2JEjR4YPH+7m5paXl0e3gZHGoWrUQvbuRbt2WL4cACIjMXgw1GrMmIHHvOq7puZcefnPWu3NiopfKUYfF2Ns4cKFACQSCWUoaTSKUQs5exbBwbffhoQgJwdDh8LLC56ed3z19KwYE6D3dhYIvIRCT6HQWyBwM/xcQUFMmzbrRKJgjeaBS7o9Wm0t8vPh7w9X1yZ8JOuzc+fOEydOtGrVKjY21tJjIVaMYtRCxGJUVNx+W1EBxqBQQKG4d9+rg/tUKLIMb3k8ARep3t4xPJ6guvqss3Oog0MntfpiVdUfQqH3rcD15PMbcJf9Dz8gLg5hYfjzT/TqhQ8/xN9/A0CHDmjRa7brdDruQUlxcXGGB3kS0gh0btRCcnLw2ms4ehT29lAoMHgwTpyAXg+5HKWldV9vvbgyV1styNfpSrXaEq22VKdTcm0EBKzy9JxSVLSsqiqzVatlOp3q8uV/1u+Ex3MQCj0dBO27zbG7o8jl/vP0RI8eGDoUJ07AwwMAoqLwj39AowGAyEg4Od137Evy86+p1Y58PoAVHTr42NmZ8k/KVLZu3Tpr1qwuXbqcPXvWzjo/AmkmWnK50az17o0ZM/Dkk+jYEXl5+OgjcI+TvN+aoW3ufMuYVqcr1WrlAoGnnZ1fhw7faLU3c3P7tmv3iYdHlFYr576r1Zbq9ZW1tdcEOicc/fv+w/j2W/ToUZehAMaPx/HjeNTdkBq9fmG7dl0fELJWobq6mnsY/Zo1ayhDSRNRjFrOrFmIiYFCcd/ofAgeTygU+gqFvgCqqjKcnPozpuHx7Fxdn3Nzm1B/T8bUWq1cX6nAryW3y9uSeq9dXFB/IXc7u7pS9FFyKioUtbUigSDIeg6HlUrlxYsX8/Ly8vLykpOTr1y5MmDAgEmTJll6XMTqUYxaFI/3uBl6F6Xyh6KiZYCgffvPeDz7e5p3sLMLgHsAHjSHX1aGt95CbS24iuzYMYSFNaTfv2tqlDqdl1DYPGNUoVD8fT/19/Hy8ho0aBCtLkiajs6NWrfKyvQrV+aLxU8GBKxqZBMJCUhJQVQUzp7FmTPYv/+RM0sL8vJmBgQ0h4N6rVZbWFiYl5dnKDM5lZWV9+4sEok63VJdXf3JJ5/4+/v//fffTs3ggxCrRtWoddNoCioqjtrZPfBx6o/25pt49lmcOoUxYyCVwhoe1paRkfHuu+/m5eVdunSptrb23h28vLw63alz586tWrWqv096enp6evpnn302d+5ccw2ctExUjVq3mzdlly/P9vaOaddOZrZOfykr6+vi4mWhy6FOnDixbNmylJQU7q2Hh0fHenr27Nm7d2/ucZ4Pt2vXrueff75t27YXL160t7/7fAghDUfVqHWzyJrNA1xcRp4509bR8XtLrIf022+/paSkPPfcc2vXru3UqZOjo+PD91coFPWP91944QVucfsJEyYEBQVlZ2d/+eWXr776qlnGTlomilHrZpF1SZRaLQMsNTWTnZ0NYNy4cfcuateQmSV/f38uRnk83qJFi1588cV///vfL7/8srBF32tATIr+6li3Ww9iMms1qtRqAbhZ6CwqF6NBQUHc24yMjDVr1nCVZlVV1b37Ozs71z9DOnjwYMO3Jk+evGLFivPnz3/77bfTpk0zz/hJy0Mxat1uHdSbtxrV6QC4WaJ802q1ubm5PB6vd+/e3Ba1Wr17927u9V3nSTnt27d/0GM+BQKBRCKJjo5es2bN1KlT6WmgpHEoRq1baWk3YLBO1+bRuxoPV426WiJGL1y4UFNT07FjR9dbq6j06dMnKSmJKzbd3Nwe/uP3+sc//rFq1apz587t2rXrhRdeMPZ4iU2gf36t2yuvxIeGpt24EfzoXY2n7qDeEjGalZUFoE+fPoYtYrE4KipqwIABjchQAHZ2dgsWLACwevVqumqFNA7FqHWTy4H734hvQnUH9ZY4N8qdGK0fo00XHR3dunXr06dP79+/34jNEttBMWrduHX1zByj5ZauRg3zS0bh4ODw9ttvA+AWKyHkcVGMWjGVChoNxGKY+eJxC54bFQrn9O8/Pyion3GbnTVrlq+v78mTJw8dOmTcloktoBi1YhY5ogegPXq0S26ua1mZmftVKrFnz+g//1zXuXNn47YsEonefPNNAGvWrDFuy8QWUIxasdJSADD/M4QOrV+//aWX7O+3UL9JZWWBMfTubZL7/ufOnevh4XH48OFjx44Zv3XSolGMWjFLVaNyuRyA+Z8Bl5UFAEadXrrN1dWVeyLTe++9Z5IOSMtFMWodLl6EXl/3urAQlZX44w8EB+PIEaxejbNnzTqY0tJSAJ5mz+/sbAAw6vTSHWJjY8Vi8Y8//pienm6qPkhLRDFqHSZNgkpV93rBAmRmIiQEO3bgyScREoKoKPONRKPRVFRU2NnZubg04Hl5RsVVo6aLUU9Pzzlz5oAKUvKYKEatVe/e+M9/cOOGufs1HNGbed14xuqKbtPFKIB//etfIpFoz5493JVVhDQExajV2LQJH36IDz/E+fMA4OCApUsxf765h8Ed0Zv/xGh+PsrLERAAnyYsUX0vvV4fGxt78OBB7q2vr+/MmTMZY8uWLdPpdMbsibRcFKNWo3t39OyJnj1huOlxwgQoFDhyxKzD4KpR858YNcX8kk6ni46O3rBhw7Rp01S3TpqMHz/ezs4uLS3Nz89v8uTJW7duvXbtmjF7JS0OxajVGDECo0Zh1Cj4+9/e+PHHWLwYAE6exKefwgw3hVuqGpXLIRbj1rpORqDVal955ZXExERnZ+ft27eLxWIAGRkZkyZNqq2tra2tlcvlO3bsmDVrVtu2bYcMGbJ69erMzEy6757cByPWoG9fVlZW93rKFHb0KAsOrnu7fDnr3p1168YANno0u3LFhMPIzMwMDw93d3fv0KHD1atXTdhTPbt3s6NHGWNMr2c7drCiIiO0qVarJ06cCMDNze23337jNh47doxb3yQyMrK6uvrChQsfffTRyJEjHRwcDL8v/v7+b7+9eceO2/87CKEYtQ7p6UyrrXt99iwrK2MnT9a9ra5maWksKYl5ezOAubkxmcz4Azh8+HBERAQXJc7OzgA8PDy++uor4/d0j8mTWceOTKFgjLFp025/8EarrKx85plnuI9w8lZzv/76K1eQTpkyRaPR1N+/qqoqJSUlNjY2MDAQwLBhhwEmELDgYBYXxzIymF5/e+erV1lhYd3roiImlzd1tKT5oxhtOa5fZxMmMIAB7LnnmLGKxdTU1BEjRnABKhaLY2Njs7Kyxo8fz20ZM2aMqcvSyZPZkiVszhzGjBGjFRUV3Mfx8/M7c+YMt3H//v3cY5anTZtWW1v7kB/PysrasEE+bBgTCuv+qAHWrh2bPZslJ7PKSrZ0KQsMZCoVY4wtX87M8g8NsTCK0ZYmKYl5ejKA+fiw775rfDt6vT45OXnQoEFcXHp5ecXFxZWWltbrKMnDwwOAj4/Pd03p6VEmT2bZ2eypp9jJk02NUYVCwT1EpFWrVjk5OdzG5ORk7rB91qxZOp2uwU2xpCT2yivMz+92njo5sbffZhMnsvnzGaMYtRkUoy1QQQGLiKj7xZ49u1z+mAeWOp0uOTk5OLhuKWgfH5+4uLiy+50LLCgoMBzpR0VFlZSUGOkTMMaYXs927WLfflsXozk5bMgQNnUqO3mSffMNu/Owu0FKS0tDQ0MBtGvX7uLFi9zGb775xs7ODsD8+fP19Q/OH0dODpNKWUQECw5mS5eynTtZeDg7c4Zi1FZQjLZMej2TyZirK+vbN9bPz2/37t0N+SmdTpeUlNS9e3cuGdu2bZuQkFBVVWXY4fTp0zdv3ryzI71MJuPuaPL399+zZ0/TB6/TseRkNmAAA1irVuyFF1h2NmOMLVjAPDxYfDwDWGAgk8luny9+pOvXr3OrlHbt2rXw1snLL7/8UiAQAJBIJE0fNmNMrWZLl7Lvv2d//MGefJJi1FZQjLZkeXmlTzzxBJeJr776qlKpfNCearU6MTGxS5cu3M7t27dPSEiorq427HDq1KmoqCgej7dw4cJ7f/zvv/8eNmyYoSytf+z/WDQa9vnnrGvXulI6MJBt3Mhefpnl5jLGmErFundnmzezHj3qdujfnx048OhmL1++zH20Hj16GM7kbt68mXuG3YoVKxo32vviYpQx9vrrLCiIYtQmUIy2cFy1KBKJAAQGBv7888937VBTUyOTydq0qXsoXqdOnWQyWf1plqNHj3Lz2twc/bvvvvvIjtq1a3fo0KHHGqdazRITWefOdfnYoQNLSGD1YvwOOh1LSmIdOtTtPGQIS019YMv5+fmdOnUC0L9/f0MpvXbtWgA8Hu+jjz56rHE+kiFGlUoWEEAxahMoRm1Cbm7uwIEDueCIiYlRqVSMMZVKlZCQ0KpVKy4ig4KCEhMTtfWOk1NTUyMjI7nvuri4xMbGFj3qos2zZ8/e29HDVVZWbt2aGhBQl4k9e7KvvmrQ0bpazWQy5utb94MRESwr6z67paamikSiwYMHK7hrphiTSqXcCDdu3Pjobh7T1at112YVFrJPP6ULnmwCxaitqK2tXbVqlb29PYCOHTu++uqrhhs6Bw0alJycXH+CJSUlJSwsjPuuq6urRCJp+DxVbW2tVCrlOurQocORI0cetKchxwUC+/btNX36sMTExzjdeasRJpUysZgB7KmnDkZFReXn59+1z/Hjxw2BvnTpUgACgWDbtm2P19PjqK5mDg6Mz2eNPb1BrAnFqG3Jzs4eMGCA4RL68PDw5ORkw3e5OfqQkJBHztE/UlZWVv/+/QHw+fzY2Niampr635XL5XFxcdz1UgDCwsIOHsxp7Dw5Y4xdvcreeEMjFvsBEIlECxcuNNSeBnq9ft68eQDs7e137NjR+M4a5oknGMD27jV1P8TyKEZtjlqt5u6IT0pKMmzk5uh79OjB5Zqfn59UKq2srGxKRxqNRiqVcpcT9ezZMz09nTFWXFwcFxfn7u7OdXRXjjfR+fPnuXkw7g4lqVRquMxAq9VGR0cDcHBw2LVrl7F6fIglSxhQdwEpadkoRm0RV4oajnMVCkXHjh25XOvQocOWLVvuKh6b4vjx4926dQNgZ2cXHh7OzUEBGDVq1LFjx4zVS32///674bar1q1by2Sympqal156iStUf/rpJ1N0yklPZ//+d939Yz/9xAAWEmK63khzQTFqc9RqNXdgW3/js88+27Fjx7vm6I2lurpaIpHweLzWrVvzeLzIyMiTTb8x/lEOHjzInb4AwC044urqmvqQGX1jGDuWASwxkTHGKiuZvT0TCGgRk5aPYtTmFBUVcXdD1t9YXFzc8PsgGyc8PByAKSbHH0Sv1yclJXXq1KlNmzZisfj48eOm7vH99xnAoqPr3g4ezAC2f7+puyUWRuuN2pz7rrvs4+PDXYtuOlqtFoDhHlMz4PF4UVFRp0+fLikpqaioMPrT7e81fDiA2wtpc3ckmHldbWJ+FKM2x2zrLufm5u7cufM898wTyz1P1MXFJSwsjDFmhgfQ9+sHd3fk5aGwEKAYtRkUozbHbE8B2bNnz6RJkxITE+v3a/5l8wFwN6oeMX2eCQQYMgQAUlMBIDwc9vZQKmsqKqpN3TWxIIpRm2O2OKtffur1+rKyMj6fb7jUyZzMFqMAhg0Dn4/MTBUAsRhDhow/d84pLS3VDF0TS6EYtTlmO7iuX/aWlZXp9Xp3d3duRSUzGzx4sKOj45kzZ8rKykzd19NP54nF7fftG8i9DQnpCuDo0aOm7pdYEMWozTHbudH6Za+lnifKcXR0DAkJ0ev1Zjk92k6vLz1//jx3RQRXCP/666+m7pdYEMWozTFbotUvey14YpQzfPhwmOW4XigUcgvsc5E9dOhQgUCQnp5eVVVl6q6JpVCM2hyLVKOWmqY3MGdVWP9UrJubW9++fTUazYkTJ8zQNbEIilGbY+ZqtP5BvQWr0SFDhtjb2586dUqpVJq6r7tmtMw5wUUsgmLU5pgt0RQKBQBuGSeLV6MikSg4OFin06WlpZm6r4EDBzo7O+fm5hYXF4Ni1AZQjNoc8yRaeXm5RqMRi8XcwqNmO5PwEGaLM3t7+/fee2/79u3cEjBDhw7l8/knTpyoqakxddfEIihGbY55YvSu3LTsTD3HnFVhbGzs5MmTuRj19PQMCAjQ6XTjxo3btm3bjRs3zDAAYk5CSw+AmFVlZWVNTY1IJHJycjJpR3flZnOoRp944gmhUJiRkaFSqcRisXk6ZYy9+eabV65ccXV1TUlJSUlJAdCzZ8+xY8dGREQMHz5cKKTfQatH1ahtMfO1982qGnVxcenfv79WqzXbpDlj7I033li/fr29vX18fPymTZvGjBkjEolyc3Pj4+NHjhwZEBAwffr0b77ZXlpqnhERk6AYtS0WuRPUnP0+nDmP63U63YwZMzZt2iQSifbu3Tt79uw5c+bs27dPLpenpKRIJJIePXrcvHnzq6++Wr78e19fhIRg4UIcOwbGzDA6YkwUo7blvgfX3ISycd2VmxafqeeYLUY1Gs3//d//JSYmOjs779271/CEagCOjo4RERFSqTQ3N/fPP//88MMPhw+fKxTijz8QH4+hQ9GmDWbOxPffQ6UCgF9+QUhI3eujR7FiBd58E2fO1LW2fj127TL1pyGPQDFqW+49uL506VKXLl1mzZpVUVFhxI6aZzXK3VP0+++/m/SeIrVaPWXKlO+++87d3T0lJeXpp59+0J7dunV76623ZLJhJSXYtQszZ6JNGxQV4dNP8cIL8PbGiBHIzoZKhbg4AKiqglyO68dkHSIAAAcBSURBVNdhmPMvLUV5uek+CmkQilHbwqUb99A3TlpaWnV19datWwcMGGDEayqHDh26ZMkSrvrTarUqlUooFLq6uhqr/ca57z1FhYWFYWFhK1euzMjI0Ov1Teyiqqpq7Nixu3fv9vT0/Omnn7gbQx/JxQUTJmDrVhQWIi8PCQmIiABj+OUXiESYMAGnTuHUqdv7X7uG/Hzk58P0a62QBrDw6vvEvM6fPz9q1CiBQCCRSDQaDbcxOzvb8DDkmJiYJj4Q9F7cJT6+vr7GbbZx3nrrLQDLli0zbNmyZYvh18Hb2zsqKioxMbG0UQ+YV6lUTz31FAA/P7+srKwmDrW0lCUns+RkJpGw06dZeDjbv5+98QabMoVNmMBiYlhMDAsOZtu2NbEf0lQUozYnNjaWq0ZDQ0Nzc3O5jfd9GLKx5ObmAujevbsR22y03bt3Axg2bJhhS1VVFTfnwz3BlCMQCIKDg+Pi4rgStSEtKxSKsLAwAG3btr1w4YKxBszFKGPszTfZ1Kl1MXriRN134+IoRi2PYtQWpaamdurUCYCjo6NUKtVqtdz2kydPdu/eHYBQKJRIJGq12ijdffDBBwC6du1q6qfmNYRcLufz+XZ2dkePHr13PHl5eQkJCREREdzNVxw/P7/p06cnJSUplcoHNXvjxo2+ffsCaN++/cWLF404YEOMKpWsdev7x+i337ING5jxnopNHg/FqI1SKpUxMTFcWTp48ODz589z27mHIXOLKwcFBWVmZja6C71en5ycHBoailt31g8ZMsSIZVqjLVmyJDAwEICXl1dUVJRMJrt27dpd+yiVyu+++y46OrpVq1aGPHVwcBg5cuSVK1fu2vnatWu9e/cG0K1bt8LCQuOONjf39rNFf/6Z7dnDtm1jly7VbfnxR3bwIDt+nO3dy/77X+P2TBqKYtSmHThwoE2bNgCcnJykUqmhOvvtt9+6dOkCwM7OLi4uzlCuNpBWq/3mm2+CgoK49PH394+Ojvbz8wPg4uKyefPmBh4mm4hOp3v99dc7duxY/xA+PDx8zZo1mZmZ944tJydHKpVGRETY2dmJxeK7ivSCggLuz6pnz55FRUVm/Bx3+PRT9ssvlurc1lGM2jqFQhETE8OlSUREREFBAbe9srJSIpFwT10eNGjQuXPnGtKaRqNJTEzkzgwACAwMTEhIqKqququjkSNHXr582YSfqmHy8vJkMllkZKSDg4MhUn19fblDeIVCcdf+JSUlR44cqb8lPz+fi+MBAwbcvHnTjGO/w4ED7JNPLNU5oRgljDHG9u3bxx29urq6ymQyw/aDBw9y5apIJNq3b99DWlCr1YmJiVxdxp0iTEhIqK6uvmu3HTt2+Pj43NuRZVVWVqakpMTGxrZt2/auElUqlT5oluncuXOtW7cGEB4eXlZWZv5hc86cYc88wyQS9uOPlhqCraMYJXVu3Ljx/PPPcwkyatQowxlA7iyqt7f39evX7/uDNTU1MpmMS1sAnTp1kslktbW1D+ro+vXr48eP53YeO3bstQc0ayn3nWVq3759TExMUlJSeXk5t1tOTg73D8+wYcMMG4ltohgld0hKSuLuNXJ3d69fLd43Q1UqVUJCgmESJigoKDExsYEnUpOSkjw9PT0CAp4/fXqn5Q6HH6K0tHT79u0vvfSSr6+vIU+dnJxGjRr1zjvvcDdojR49mjtlQWwZxSi527Vr18aNG8elxqRJk+57yk+pVEqlUsO9nv37909KSnrciaPCwsJ3U1ODMzKCMzIW5uWVPbiAtTjDLBO3rh2fz7e3t3/++eeNdU0YsWo8RuvJkPv54osvXn/9dZVK5evru2XLlokTJ3Lbb968uWnTpo8//ph75nt4eLhEIhk7dmyjO/pBLo8vLKzS6TyFwkXt2j3l7m6cD2AaxcXFBw4c+OuvvyIjI4ODg2m1UAKAYpQ8UEFBQXR09C+//AIgKipq1apVn3/++YYNG7h1PcLDw1esWDFixIimd3RNo1lx6VKGSgUgwsNjcWCgK8UTsR4Uo+Rh9Hr9xo0bFy1aVFVV5ejoWFNTw+Pxxo0bt3Tp0pCQECN2xIBdJSUfFRZW6/XednZL2rXrIRJdVqu577ZzcPCyszNid4QYEcUoebQLFy7MmzevR48e165dW7x4seG6eqMrqKlZfulSdmUlDxjv41OsVge5uAAY6ubWXSQyUaeENBHFKGle9MC3xcV75fJILy8w9qKfn6VHRMgjUIyS5kjH2M6Skp8VCq4InRMQ4MintXFJM0Un8klzJODxAPQSiUZ7egKwr7fONCHNDcUoab587Oy60ilR0uzRgRIhhDQJnRslzZRSq2WAO11ASpo9ilFCCGkSOqgnhJAmoRglhJAmoRglhJAmoRglhJAmoRglhJAm+X8U1V9jMIYuMgAAAjB6VFh0cmRraXRQS0wgcmRraXQgMjAyMC4wOS4xAAB4nHu/b+09BiDgAWJGBgiQB2IlIG5gZEvQANLMLGwJFiCakQUhAKUVDJBoJgSNrg7TIFwmYlGBoRRdhlNBAeR+KMWuABFmZodoQNAQCSYMCQ4FkH//M8JoAQWQOCsLNwNHAoNgBhODuAIjUwYTo3gCE3MCE68CM2cGE7NEAgsrAysbA5scAztHBhO7cAK7mAKHCAMnVwKneAIXdwYTN08Cj0QGE4+kAi9fBhOvQAKfVAK/VAYTv3SCgHQGk6BQgqAog5BwBpOYHIOMHIOsHIMICysjEzOnOBu7sJAgAwcbFzePBDMnG58Uv7QArzgsghjkG6S793eYX9gP4nhwstvf/c1gD2Jz32FwaM81BbNzt2s5RKqpgNXYzvI/MLt0ogOI/bYn7MAqbWcw+3PFtAMeAZJgNkNq9oEfqjvA6tkZRA+k3/MAs6N+nLIXFbsOZvO++2Hfd8DjAIituDbCYW5JMpht+KXPQfOzApi9RU3PIYyBCWI+T7tDjyQrmM0c1+KgsHQqmB3255u9WE8wmP2QYeb+wNvuYL2ZT5UObN5WCGZvCC860HHJGswO5+U7cFreDOyvzaU2ttX7a8Hii7PnHnDbLQF226GdbXYdjJVg9pGyZgfv6nYw245/r4PFcog5HpvmOjTsiwTbe+WEhkOrxBQwm0s15IBmhRfYfMFLJw9cZ2sEs70/zTzwxikNzBYDAFHjlN45N0kPAAACMnpUWHRNT0wgcmRraXQgMjAyMC4wOS4xAAB4nJ1WS27cMAzd+xS6wAgkRVHissj0AxRJgBToHbrqprl/qc/IHiQBYg4MDJ9pPvMvy+vr3/hlC+33cv35519YP7puW0gYEocA716qGn4TADT7C0aoUockJKVxQDQthIfwEcXx2oZFppKnBKn6WCgCNr+bbYHq9IWiSGksF4jCSC6WS4rEIw6OmbN4WVKmHlGKwJp9LGzZoDRiS5qdLClKqTAqbaH5snsxD6jiyG6p7MtLwJhrLrPrKrCXRZnriA2TOLvOalR7fY0lZwYfC0eWkkaGMrJ7AgohzllImLy+EMHsFyjqnCNuOc1DkiL+GpHKzDNkH4t1CWpOs9JEvuy2yvCNpRRnvzTbKjL4NLF7jgh1Tk9BPObl25m9CywwvFK567rPs9h+UdS5MbPKcaafzvhCkuZm0ELFx2JdB5VGzcGWhI8lR4WxpVqNCL2+KPWNab3LcwOfZ7HzKPXN0OZo8p1maSfJ2ipFQQ8sz29Z8AMWsRkUHXMJcOfLCRaO1Yo0bKvenWq/3rK88yGydW4db+gAjY5uoJ2YU2P30tLQUZM68wK4Aw4Iy4YD5aUxSRYwqSxQ2jfTDdTuG90AwUHTumACDbRs7I14BLujdrt9gww2k3ARmNR8owWWbxYM7hoDy1G7TTuQDmiBujSlg6mpAVeuDRAtoD248ZhFtueA9AAS7OAxhIcf37uNPWNTGpra/pvm69N1+w9/eaUC90aVpwAAAXh6VFh0U01JTEVTIHJka2l0IDIwMjAuMDkuMQAAeJwlkjtuIzEQRK+yoQRQRP8/cCjAoTfY0HA0uU7gw281hQGImQJfdbE4z+fz3+377+Pn/l6/Lr5un/fr9njJhfXS64VH73iBcN2+7i98zJaL//zeHrrFNHvZdvPg9QFFXdSXbrJ2g2I7SSSWbG13OUoxlS7a1W3eb4wtA1I2VQek2EpRvXgTFb255tZeD9reEVQHjCyy9eBtWjEgBkmxzrYsC7OjCbcff2YThQTfAjtkSARS0JZQ1hiyU6JGckkrB+ikZQBlE6tN+qRKOkoKM+OEpCy5PmyLkOoI2WOD5FLEaMXQhY+AOVYoLjKMxyMUI0eQbIRhIO0FRMnfcyPSfMKBEJ4tXp7nAEWIPYxNi2gF9ok5oMtnj253HV/bFqm8UImzFcrxjcr5KK1CJy7uBzGnIy/MnLbQn9qxFsEMVEMWxHTMG4fh0zN+hCF1Z067c0M593LcLWXdf/8DMjWCK33TS9MAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7f0bdd8b0120>"
+       "<rdkit.Chem.rdchem.Mol at 0x7f581b6b11c0>"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11225,7 +11334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -11245,7 +11354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -11265,7 +11374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
@@ -11285,7 +11394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
@@ -11312,7 +11421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {
@@ -11332,7 +11441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [
     {

--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -688,7 +688,7 @@ class Pockets(LocalInitializer, PocketsProvider):
     opencadd.databases.klifs.core.PocketsProvider
     """
 
-    def by_structure_klifs_id(self, structure_klifs_id):
+    def by_structure_klifs_id(self, structure_klifs_id, extension="mol2"):  # pylint: disable=W0221
 
         # Get kinase pocket from structure ID
         structures_local = Structures(self._database, self._path_to_klifs_download)
@@ -702,7 +702,7 @@ class Pockets(LocalInitializer, PocketsProvider):
 
         # Load pocket coordinates from file
         pocket_path = (
-            self._path_to_klifs_download / structure["structure.filepath"] / "pocket.mol2"
+            self._path_to_klifs_download / structure["structure.filepath"] / f"pocket.{extension}"
         )
         mol2_df = DataFrame.from_file(pocket_path)
         # Get number of atoms per residue

--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -308,7 +308,7 @@ class _LocalDatabaseGenerator:
         for index, row in klifs_metadata.iterrows():
 
             # Depending on whether alternate model and chain ID is given build file path:
-            mol2_path = metadata_to_filepath(
+            filepath = metadata_to_filepath(
                 ".",
                 row["species.klifs"],
                 row["kinase.klifs_name"],
@@ -319,7 +319,7 @@ class _LocalDatabaseGenerator:
                 extension="",
                 in_dir=True,
             )
-            filepaths.append(mol2_path)
+            filepaths.append(filepath)
 
         klifs_metadata["structure.filepath"] = filepaths
 
@@ -704,10 +704,10 @@ class Pockets(LocalInitializer, PocketsProvider):
         pocket_path = (
             self._path_to_klifs_download / structure["structure.filepath"] / f"pocket.{extension}"
         )
-        mol2_df = DataFrame.from_file(pocket_path)
+        dataframe = DataFrame.from_file(pocket_path)
         # Get number of atoms per residue
         # Note: sort=False important otherwise negative residue IDs will be sorted to the top
-        number_of_atoms_per_residue = mol2_df.groupby(
+        number_of_atoms_per_residue = dataframe.groupby(
             ["residue.name", "residue.id"], sort=False
         ).size()
 
@@ -716,27 +716,27 @@ class Pockets(LocalInitializer, PocketsProvider):
         for klifs_id, n in zip(klifs_ids, number_of_atoms_per_residue):
             klifs_ids_per_atom.extend([klifs_id] * n)
         # Add column for KLIFS position IDs to molecule
-        mol2_df["residue.klifs_id"] = klifs_ids_per_atom
-        mol2_df = mol2_df[["residue.id", "residue.klifs_id"]].drop_duplicates()
+        dataframe["residue.klifs_id"] = klifs_ids_per_atom
+        dataframe = dataframe[["residue.id", "residue.klifs_id"]].drop_duplicates()
 
         # Add KLIFS IDs that are missing in pocket and fill with "_"
         full_klifs_ids_df = pd.Series(range(1, 86), name="residue.klifs_id").to_frame()
-        mol2_df = full_klifs_ids_df.merge(mol2_df, on="residue.klifs_id", how="left")
-        mol2_df.fillna("_", inplace=True)
+        dataframe = full_klifs_ids_df.merge(dataframe, on="residue.klifs_id", how="left")
+        dataframe.fillna("_", inplace=True)
 
         # Add column for KLIFS regions
-        mol2_df = mol2_df.merge(POCKET_KLIFS_REGIONS, on="residue.klifs_id", how="left")
-        mol2_df = mol2_df.astype({"residue.klifs_id": "Int64"})
+        dataframe = dataframe.merge(POCKET_KLIFS_REGIONS, on="residue.klifs_id", how="left")
+        dataframe = dataframe.astype({"residue.klifs_id": "Int64"})
 
         # Standardize DataFrame
-        mol2_df = self._standardize_dataframe(
-            mol2_df,
+        dataframe = self._standardize_dataframe(
+            dataframe,
             DATAFRAME_COLUMNS["pockets"],
         )
         # Add KLIFS region and color  TODO not so nice to have this after standardization
-        mol2_df = self._add_klifs_region_details(mol2_df)
+        dataframe = self._add_klifs_region_details(dataframe)
 
-        return mol2_df
+        return dataframe
 
 
 class Coordinates(LocalInitializer, CoordinatesProvider):
@@ -752,9 +752,9 @@ class Coordinates(LocalInitializer, CoordinatesProvider):
     ):  # pylint: disable=W0221
 
         filepath = self._to_filepath(structure_klifs_id_or_filepath, entity, extension)
-        mol2_df = DataFrame.from_file(filepath)
-        mol2_df = self._add_residue_klifs_ids(mol2_df, filepath)
-        return mol2_df
+        dataframe = DataFrame.from_file(filepath)
+        dataframe = self._add_residue_klifs_ids(dataframe, filepath)
+        return dataframe
 
     def to_rdkit(
         self, structure_klifs_id_or_filepath, entity="complex", extension="mol2", compute2d=True
@@ -805,13 +805,13 @@ class Coordinates(LocalInitializer, CoordinatesProvider):
             filepath = structure_klifs_id_or_filepath
         return Path(filepath)
 
-    def _add_residue_klifs_ids(self, mol2_df, filepath):
+    def _add_residue_klifs_ids(self, dataframe, filepath):
         """
         Add KLIFS position IDs from the KLIFS metadata as additional column.
 
         Parameters
         ----------
-        mol2_df : pandas.DataFrame
+        dataframe : pandas.DataFrame
             Structural data.
 
         Returns
@@ -832,9 +832,9 @@ class Coordinates(LocalInitializer, CoordinatesProvider):
 
         # Get pocket
         pockets_local = Pockets(self._database, self._path_to_klifs_download)
-        mol2_df_pocket = pockets_local.by_structure_klifs_id(structure_klifs_id)
+        pocket_dataframe = pockets_local.by_structure_klifs_id(structure_klifs_id)
 
         # Merge pocket DataFrame with input DataFrame
-        mol2_df = mol2_df.merge(mol2_df_pocket, on="residue.id", how="left")
+        dataframe = dataframe.merge(pocket_dataframe, on="residue.id", how="left")
 
-        return mol2_df
+        return dataframe

--- a/opencadd/tests/databases/test_klifs_local_remote.py
+++ b/opencadd/tests/databases/test_klifs_local_remote.py
@@ -360,12 +360,15 @@ class TestsFromStructureIds:
             structure_klifs_id = structure_klifs_ids
 
             result_remote = REMOTE.pockets.by_structure_klifs_id(structure_klifs_ids)
-            result_local = LOCAL.pockets.by_structure_klifs_id(structure_klifs_ids)
+            result_local_mol2 = LOCAL.pockets.by_structure_klifs_id(structure_klifs_ids, "mol2")
+            result_local_pdb = LOCAL.pockets.by_structure_klifs_id(structure_klifs_ids, "pdb")
 
             check_dataframe(result_remote, DATAFRAME_COLUMNS["pockets"])
-            check_dataframe(result_local, DATAFRAME_COLUMNS["pockets"])
+            check_dataframe(result_local_mol2, DATAFRAME_COLUMNS["pockets"])
+            check_dataframe(result_local_pdb, DATAFRAME_COLUMNS["pockets"])
 
-            assert all(result_local == result_remote)
+            assert all(result_local_mol2 == result_local_pdb)
+            assert all(result_local_mol2 == result_remote)
 
     @pytest.mark.parametrize("structure_klifs_ids", [100000, "XXX"])
     def test_by_structure_klifs_id_raise(self, structure_klifs_ids):


### PR DESCRIPTION
## Description
`opencadd.databases.klifs` allows interaction with local KLIFS data. 
So far, it was only possible to get pocket information (i.e. residue PDB ID to KLIFS index mapping) based on mol2 files. 
In this PR, we add the same based on pdb files (KLIFS offers both mol2 and pdb files as download).

## Todos
  - [x] Add `extension` argument to `Pockets.from_structure_klifs_id` signature
  - [x] Generalize all variables with `mol2` mention that now refer to pdb- or mol2-based data (e.g. `mol2_df` > `dataframe` or `mol2_path` > `filepath`)
  - [x] Add unit tests for local pocket from pdb file
  - [x] Pin `parso` version to 0.8.1 to resolve conflict with `jedi`

## Questions
None

## Status
- [x] Ready to go