### PR TITLE
fix serialization errors in bravado through subclassing

### DIFF
--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -24,7 +24,8 @@ from .schema import (
     DATAFRAME_COLUMNS,
     POCKET_KLIFS_REGIONS,
 )
-from .utils import KLIFS_CLIENT, PATH_DATA, metadata_to_filepath, filepath_to_metadata
+from .remote import KLIFS_CLIENT
+from .utils import PATH_DATA, metadata_to_filepath, filepath_to_metadata
 from opencadd.io import DataFrame, Rdkit
 
 # Get the newest file version (* = YYYYMMDD)

--- a/opencadd/databases/klifs/session.py
+++ b/opencadd/databases/klifs/session.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from . import remote
 from . import local
-from .utils import KLIFS_CLIENT
+from .remote import KLIFS_CLIENT
 
 
 class Session:

--- a/opencadd/databases/klifs/utils.py
+++ b/opencadd/databases/klifs/utils.py
@@ -9,8 +9,6 @@ import logging
 from pathlib import Path
 import re
 
-from bravado.client import SwaggerClient
-
 _logger = logging.getLogger(__name__)
 PATH_DATA = Path(__file__).parent / ".." / ".." / "data"
 

--- a/opencadd/databases/klifs/utils.py
+++ b/opencadd/databases/klifs/utils.py
@@ -12,10 +12,6 @@ import re
 from bravado.client import SwaggerClient
 
 _logger = logging.getLogger(__name__)
-
-KLIFS_API_DEFINITIONS = "https://klifs.net/swagger/swagger.json"
-KLIFS_CLIENT = SwaggerClient.from_url(KLIFS_API_DEFINITIONS, config={"validate_responses": False})
-
 PATH_DATA = Path(__file__).parent / ".." / ".." / "data"
 
 


### PR DESCRIPTION
Problem fixed by @jaimergp 
PR description by @dominiquesydow  

## Description

Using `bravado`'s `SwaggerClient` in a multiprocessing protocol causes a `RecursionError`.

#### Minimal example
```bash
from multiprocessing import Pool

from bravado.client import SwaggerClient

API_DEFINITIONS = "https://klifs.net/swagger/swagger.json"
CLIENT = SwaggerClient.from_url(API_DEFINITIONS, config={"validate_responses": False})

pool = Pool(processes=2)
type_list = pool.map(type, [CLIENT, CLIENT])
print(type_list)
pool.close()
pool.join()
```

#### Error
```bash
Process ForkPoolWorker-2:
Traceback (most recent call last):
  File "/home/dominique/.local/miniconda/envs/kissim/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/dominique/.local/miniconda/envs/kissim/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/dominique/.local/miniconda/envs/kissim/lib/python3.8/multiprocessing/pool.py", line 114, in worker
    task = get()
  File "/home/dominique/.local/miniconda/envs/kissim/lib/python3.8/multiprocessing/queues.py", line 358, in get
    return _ForkingPickler.loads(res)
  File "/home/dominique/.local/miniconda/envs/kissim/lib/python3.8/site-packages/bravado/client.py", line 170, in __getattr__
    return self._get_resource(item)    
return self._get_resource(item)
  File "/home/dominique/.local/miniconda/envs/kissim/lib/python3.8/site-packages/bravado/client.py", line 148, in _get_resource
    resource = self.swagger_spec.resources.get(item)

  # Repeating the line 170 and 148 errors over and over again

RecursionError: maximum recursion depth exceeded
```

#### Solution
Fix serialization errors in `bravado` through subclassing (defining `__getstate__` and `__setstate`).

## Todos
  - [x] Add `SerializableSwaggerClient` class (subclassing `SwaggerClient` and defining `__getstate__` and `__setstate__`
  - [x] Move `KLIFS_API_DEFINITIONS` and `KLIFS_CLIENT` from `utils` to `remote` module; update all associated imports

## Questions

- [ ] Maybe this serialization protocol could be added directly to `bravado`'s `SwaggerClient`? https://github.com/Yelp/bravado/issues/471

## Status
- [ ] Ready to go