### PR TITLE
Fetch information for multiple kinases with _one_ API call

### DIFF
--- a/opencadd/databases/klifs/remote.py
+++ b/opencadd/databases/klifs/remote.py
@@ -122,32 +122,11 @@ class Kinases(RemoteInitializer, KinasesProvider):
     def by_kinase_name(self, kinase_names, species=None):
 
         kinase_names = self._ensure_list(kinase_names)
-        # Use KLIFS API (send requests iteratively)
-        kinases = self._multiple_remote_requests(self._by_kinase_name, kinase_names, species)
-        # Standardize DataFrame
-        kinases = self._standardize_dataframe(
-            kinases, DATAFRAME_COLUMNS["kinases"], REMOTE_COLUMNS_MAPPING["kinases"]
-        )
-        return kinases
-
-    def _by_kinase_name(self, kinase_name, species=None):
-        """
-        Get kinases by kinase name.
-
-        Parameters
-        ----------
-        kinase_name : str
-            Kinase name.
-
-        Returns
-        -------
-        pandas.DataFrame or None
-            Kinases (rows) with columns as described in the class docstring.
-        """
-
+        # FIXME: This might be a bug in KLIFS (expected behaviour: list of str; instead of str)
+        kinase_names = ", ".join(kinase_names)
         # Use KLIFS API
         result = (
-            self._client.Information.get_kinase_ID(kinase_name=kinase_name, species=species)
+            self._client.Information.get_kinase_ID(kinase_name=kinase_names, species=species)
             .response()
             .result
         )
@@ -157,7 +136,6 @@ class Kinases(RemoteInitializer, KinasesProvider):
         kinases = self._standardize_dataframe(
             kinases, DATAFRAME_COLUMNS["kinases"], REMOTE_COLUMNS_MAPPING["kinases"]
         )
-
         return kinases
 
 

--- a/opencadd/structure/superposition/engines/base.py
+++ b/opencadd/structure/superposition/engines/base.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 
 
 class BaseAligner:
-    """"""
+    """ """
 
     def calculate(self, structures, *args, **kwargs):
         """


### PR DESCRIPTION
## Description
Fetch information for multiple kinases with _one_ API call (faster, cleaner!).

## Todos
  - [x] Pass multiple kinase names to KLIFS API `Information.get_kinase_ID(kinase_name=kinase_names, species=species)`; previously per kinase one API call

## Questions
- [x] In KLIFS API `Information.get_kinase_ID(kinase_name=kinase_names, species=species)`, the `kinase_name` parameter seems to allow multiple kinase names only as string (e.g. `"ABL1, EGFR"`) instead of a list of strings (e.g. `["ABL1", "EGFR"]`)
  - List of strings raises `ValidationError`:
    ```
    Failed validating 'type' in schema:
        {'description': 'The name (or multiple names separated by a comma) of '
                        '(a) specfic kinase(s) (e.g. ABL1).',
         'in': 'query',
         'name': 'kinase_name',
         'required': True,
         'type': 'string'}
    ``` 
   - Ask @AJK-dev if this behavior is intended

## Status
- [x] Ready to go