### PR TITLE
NGLview: Read PDB text via TextStructure

### DIFF
--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -145,7 +145,10 @@ class _LocalDatabaseGenerator:
         # Unify column 'kinase.hgnc': Sometimes several kinase names are available, e.g. "EPHA7 (EphA7)"
         # Column "kinase.hgnc": Retain only first kinase name, e.g. EPHA7
         # Column "kinase.all_names": Save all kinase names as list, e.g. [EPHA7, EphA7]
-        kinase_names = [self._format_kinase_names(i) for i in klifs_export["kinase.names"]]
+        kinase_names = [
+            self._format_kinase_names(i)
+            for i in klifs_export["kinase.names"]  # pylint: disable=E1136
+        ]
         klifs_export["kinase.names"] = kinase_names
         klifs_export.insert(1, "kinase.hgnc_name", [i[0] for i in kinase_names])
         klifs_export.insert(2, "kinase.klifs_name", [i[-1] for i in kinase_names])
@@ -178,7 +181,9 @@ class _LocalDatabaseGenerator:
         )
 
         # Unify column 'alternate model' with corresponding column in KLIFS_export.csv
-        klifs_overview["structure.alternate_model"].replace(" ", "-", inplace=True)
+        klifs_overview["structure.alternate_model"].replace(  # pylint: disable=E1136
+            " ", "-", inplace=True
+        )
         # Drop column for kinase name; will be taken from KLIFS_export.csv file upon table merge
         klifs_overview.drop(columns=["kinase.klifs_name"], inplace=True)
 

--- a/opencadd/databases/klifs/remote.py
+++ b/opencadd/databases/klifs/remote.py
@@ -236,7 +236,7 @@ class Ligands(RemoteInitializer, LigandsProvider):
         kinases_remote = Kinases(self._client)
         kinases = kinases_remote.by_kinase_name(kinase_names)
         # Select and rename columns to indicate columns involved in query
-        kinases = kinases[
+        kinases = kinases[  # pylint: disable=E1136
             ["kinase.klifs_id", "kinase.klifs_name", "kinase.hgnc_name", "species.klifs"]
         ]
         kinases.rename(

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -354,8 +354,9 @@ class Pocket(PocketBase):
             If returned number of CA atoms is larger than 1.
         """
 
-        ca_atoms = self.data[
-            (self.data["residue.id"].isin(residue_ids)) & (self.data["atom.name"] == "CA")
+        ca_atoms = self.data[  # pylint: disable=E1136
+            (self.data["residue.id"].isin(residue_ids))  # pylint: disable=E1136
+            & (self.data["atom.name"] == "CA")  # pylint: disable=E1136
         ]
 
         if len(ca_atoms) <= len(residue_ids):

--- a/opencadd/structure/pocket/viewer.py
+++ b/opencadd/structure/pocket/viewer.py
@@ -237,7 +237,8 @@ class PocketViewer:
             )
         self.structure_names.append(pocket.name)
         # Add structure
-        self.viewer.add_component(pocket._text, ext=pocket._extension)
+        component = nglview.TextStructure(pocket._text, ext=pocket._extension)
+        self.viewer.add_component(component)
         # Save the structure's NGLview component
         self._components_structures[pocket.name] = self._component_counter
         self._component_counter += 1

--- a/opencadd/structure/superposition/engines/base.py
+++ b/opencadd/structure/superposition/engines/base.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 
 
 class BaseAligner:
-    """"""
+    """ """
 
     def calculate(self, structures, *args, **kwargs):
         """


### PR DESCRIPTION
## Description
Update `nglview` API usage when adding a component from a PDB block string.

Instead of
```python
view = nglview.NGLWidget()
view.add_component(pdb_text, ext="pdb")
```

use

```python
view = nglview.NGLWidget()
component = nglview.TextStructure(pdb_text, ext="pdb")
view.add_component(component)
```

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Use `TextStructure` to read PDB block string

## Questions
None

## Status
- [x] Ready to go