### PR TITLE
Pocket: Add pocket/sphere names to NGL GUI

### DIFF
--- a/opencadd/structure/pocket/viewer.py
+++ b/opencadd/structure/pocket/viewer.py
@@ -238,7 +238,7 @@ class PocketViewer:
         self.structure_names.append(pocket.name)
         # Add structure
         component = nglview.TextStructure(pocket._text, ext=pocket._extension)
-        self.viewer.add_component(component)
+        self.viewer.add_component(component, name=f"{pocket.name}")
         # Save the structure's NGLview component
         self._components_structures[pocket.name] = self._component_counter
         self._component_counter += 1


### PR DESCRIPTION
## Description
Add descriptive name to NGL GUI.

![image](https://user-images.githubusercontent.com/7207093/124754485-923ca300-df2a-11eb-9c3f-d6d79f2170ea.png)
- First entry refers to structure name (done in this example)
- Second entry "shape" refers to subpocket center (not done yet in this example)

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add pocket name to structure entry in NGL GUI (e.g. "12347")
  - [ ] Add subpocket name to sphere entry in NGL GUI (e.g. "12347 subpocket"); needs [JavaScript inject](https://github.com/dominiquesydow/dynophores/blob/1ea8189fd461766a1d1a5f5b6262aa04ca3725f9/dynophores/viz/view3d/interactive.py#L155)

## Questions
None

## Status
- [ ] Ready to go