### PR TITLE
Raise exceptions for unexpected KLIFS pockets

### DIFF
--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -698,6 +698,14 @@ class Pockets(LocalInitializer, PocketsProvider):
         # Get kinase pocket from structure ID
         structures_local = Structures(self._database, self._path_to_klifs_download)
         structure = structures_local.by_structure_klifs_id(structure_klifs_id).squeeze()
+
+        # CHECK: Number of KLIFS pocket sequence equals 85?
+        pocket_sequence = structure["structure.pocket"]
+        if len(pocket_sequence) != 85:
+            raise ValueError(
+                f"Number of KLIFS pocket sequence is {len(pocket_sequence)} but must be 85."
+            )
+        
         # Get list of KLIFS positions (starting at 1) excluding gap positions
         klifs_ids = [
             index
@@ -710,6 +718,16 @@ class Pockets(LocalInitializer, PocketsProvider):
             self._path_to_klifs_download / structure["structure.filepath"] / f"pocket.{extension}"
         )
         dataframe = DataFrame.from_file(pocket_path)
+        
+        # CHECK: Number of residues in KLIFS pocket sequence and structure file are the same?
+        structure_residues = dataframe[["residue.name", "residue.id"]].drop_duplicates()
+        if len(klifs_ids) != len(structure_residues):
+            raise ValueError(
+                f"Number of KLIFS pocket residues are not equal in"
+                f"pocket sequence string ({len(klifs_ids)}) and "
+                f"pocket structure file ({len(structure_residues)})."
+            )
+
         # Get number of atoms per residue
         # Note: sort=False important otherwise negative residue IDs will be sorted to the top
         number_of_atoms_per_residue = dataframe.groupby(

--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -705,7 +705,7 @@ class Pockets(LocalInitializer, PocketsProvider):
             raise ValueError(
                 f"Number of KLIFS pocket sequence is {len(pocket_sequence)} but must be 85."
             )
-        
+
         # Get list of KLIFS positions (starting at 1) excluding gap positions
         klifs_ids = [
             index
@@ -718,7 +718,7 @@ class Pockets(LocalInitializer, PocketsProvider):
             self._path_to_klifs_download / structure["structure.filepath"] / f"pocket.{extension}"
         )
         dataframe = DataFrame.from_file(pocket_path)
-        
+
         # CHECK: Number of residues in KLIFS pocket sequence and structure file are the same?
         structure_residues = dataframe[["residue.name", "residue.id"]].drop_duplicates()
         if len(klifs_ids) != len(structure_residues):


### PR DESCRIPTION
## Description
Handle unexpected KLIFS pockets. Detailed description: #86 

## Questions
  - [x] Case 1: What if missing residues in sequence are not missing in structure (file)? Should not happen; inform KLIFS maintainers.
  - [x] Case 2: What if KLIFS pocket sequence not 85 residues? Some kinase structures are quite irregular but will stay in KLIFS for completeness; just raise an error in `opencadd` indicating a problematic structure.

## Todos
  - [x] First round: Raise specific exceptions:
    - [x] Case 1: Missing residues in sequence are not missing in structure (file)?
    - [x] Case 2: KLIFS pocket sequence not 85 residues?
  - [x] Second round: Can any of these exceptions be fixed - in KLIFS or in `opencadd`?
    - [x] Case 1: Yes, this should not happen in KLIFS, thus the fix lays with KLIFS. But: Keep exception in `opencadd` to catch more of such irregularities.
    - [x] Case 2: No easy fix right now in KLIFS. Keep exception in `opencadd` so that structure can be skipped in downstream applications such as `kissim`.


## Status
- [x] Ready to go