### PR TITLE
MmLigner fix

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -18,3 +18,12 @@ Eventually, we will have a ``conda`` package, but for now you need to create a n
     python -m pip install https://github.com/volkamerlab/opencadd/archive/master.tar.gz
 
 6. Run ``superposer -h`` to test it works.
+
+7. Workaround for MMLigner::
+    conda config --add channels conda-forge 
+    conda activate base
+    conda install conda-build
+    conda build devtools/conda-recipes/mmligner/
+    (conda activate opencadd)
+    conda install -c local mmligner pip
+    python -m pip install -e . --no-deps

--- a/opencadd/structure/superposition/cli.py
+++ b/opencadd/structure/superposition/cli.py
@@ -107,16 +107,28 @@ def main():
         result, *_empty = align(
             [reference_model, mobile_model], method=METHODS[args.method], **args.method_options
         )
-        _logger.log(
-            25,  # this the level id for results
-            "RMSD for alignment #%d between `%s` and `%s` is %.1fÅ",
-            i,
-            reference_id,
-            mobile_id,
-            result["scores"]["rmsd"],
-        )
-        for j, structure in enumerate(result["superposed"], 1):
-            structure.write(f"superposed_{args.method}_{i}_{j}.pdb")
-            _logger.debug(
-                "Wrote superposed model #%d to %s", j, f"superposed_{args.method}_{i}_{j}.pdb"
+
+        # checks if the superposition is done, if not, there was no structural alignemnt found (for mmligner)
+        if "superposed" in result:
+            _logger.log(
+                25,  # this the level id for results
+                "RMSD for alignment #%d between `%s` and `%s` is %.1fÅ",
+                i,
+                reference_id,
+                mobile_id,
+                result["scores"]["rmsd"],
+            )
+            for j, structure in enumerate(result["superposed"], 1):
+                structure.write(f"superposed_{args.method}_{i}_{j}.pdb")
+                _logger.debug(
+                    "Wrote superposed model #%d to %s", j, f"superposed_{args.method}_{i}_{j}.pdb"
+                )
+        else:
+            _logger.log(
+                25,
+                "`%s` found no alignment for #%d between `%s` and `%s`.",
+                args.method,
+                i,
+                reference_id,
+                mobile_id
             )

--- a/opencadd/structure/superposition/cli.py
+++ b/opencadd/structure/superposition/cli.py
@@ -130,5 +130,5 @@ def main():
                 args.method,
                 i,
                 reference_id,
-                mobile_id
+                mobile_id,
             )

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -94,8 +94,11 @@ class MMLignerAligner(BaseAligner):
             )
             # We need access to the temporary files at parse time!
             result = self._parse_metadata(output.decode())
-            superposed_models = self._calculate_transformed(structures, result["metadata"])
-            result["superposed"] = superposed_models
+            
+            # checks if there is metadata in the dict, if not, there was no significant alignment found.
+            if "metadata" in result:       
+                superposed_models = self._calculate_transformed(structures, result["metadata"])
+                result["superposed"] = superposed_models
         return result
 
     def _parse_metadata(self, output):
@@ -138,23 +141,29 @@ class MMLignerAligner(BaseAligner):
             elif "Print Quaternion matrix" in line:
                 quaternion = [[float(x) for x in next(lines).split()] for _ in range(4)]
 
-        # fixed_com, moving_com, rotation and quaternion can only be obtained
-        # if the patched mmligner is used (check /devtools/conda-recipes/mmligner)
-        # -- this will fail in CI for now --
-        translation = fixed_com - moving_com
+        # checks if there is a signifcant alignment
+        if(rmsd == 0 and coverage == 0):
+            return {
+                "scores": {"rmsd": rmsd, "score": ivalue, "coverage": coverage}
+            } 
+        else:
+            # fixed_com, moving_com, rotation and quaternion can only be obtained
+            # if the patched mmligner is used (check /devtools/conda-recipes/mmligner)
+            # -- this will fail in CI for now --
+            translation = fixed_com - moving_com
 
-        alignment = fasta.FastaFile()
-        alignment.read("temp__1.afasta")
+            alignment = fasta.FastaFile()
+            alignment.read("temp__1.afasta")
 
-        return {
-            "scores": {"rmsd": rmsd, "score": ivalue, "coverage": coverage},
-            "metadata": {
-                "alignment": alignment,
-                "rotation": rotation,
-                "translation": translation,
-                "quaternion": quaternion,
-            },
-        }
+            return {
+                "scores": {"rmsd": rmsd, "score": ivalue, "coverage": coverage},
+                "metadata": {
+                    "alignment": alignment,
+                    "rotation": rotation,
+                    "translation": translation,
+                    "quaternion": quaternion,
+                },
+            }
 
     def _parse_scoring(self, output):
         """

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -94,9 +94,9 @@ class MMLignerAligner(BaseAligner):
             )
             # We need access to the temporary files at parse time!
             result = self._parse_metadata(output.decode())
-            
+
             # checks if there is metadata in the dict, if not, there was no significant alignment found.
-            if "metadata" in result:       
+            if "metadata" in result:
                 superposed_models = self._calculate_transformed(structures, result["metadata"])
                 result["superposed"] = superposed_models
         return result
@@ -142,10 +142,8 @@ class MMLignerAligner(BaseAligner):
                 quaternion = [[float(x) for x in next(lines).split()] for _ in range(4)]
 
         # checks if there is a signifcant alignment
-        if(rmsd == 0 and coverage == 0):
-            return {
-                "scores": {"rmsd": rmsd, "score": ivalue, "coverage": coverage}
-            } 
+        if rmsd == 0 and coverage == 0:
+            return {"scores": {"rmsd": rmsd, "score": ivalue, "coverage": coverage}}
         else:
             # fixed_com, moving_com, rotation and quaternion can only be obtained
             # if the patched mmligner is used (check /devtools/conda-recipes/mmligner)


### PR DESCRIPTION
## Description
MMLigner does not find significant alignments, if the structures are too different.
This results in an UnboundLocalError.
In this case, the RMSD and coverage will be set to 0 and it is printed, that the method did not found an alignment.
Updated the documentation on installing for the workaround with updated MMLigner. This workaround is already used in the CI.
This should fix the issue #71.

## Todos
  - [x] Updated docs for Workaround with updated MMLigner
  - [x] Check if the method found an alignment. Print notification if not.



## Status
- [x] Ready to go