### PR TITLE
Add disclaimer about dev stages for different submodules

### DIFF
--- a/opencadd/__init__.py
+++ b/opencadd/__init__.py
@@ -10,3 +10,19 @@ versions = get_versions()
 __version__ = versions["version"]
 __git_revision__ = versions["full-revisionid"]
 del get_versions, versions
+
+print(
+    """
+    Please note the following development stages of opencadd's submodules:
+
+    Pre-release
+    -----------
+    - opencadd.databases.klifs
+    - opencadd.structure.pocket
+
+    Work-in-progress
+    ----------------
+    - opencadd.io
+    - opencadd.structure.superposition
+    """
+)


### PR DESCRIPTION
## Description
We'd like to submit `opencadd` to `conda-forge`. The package consists of quite different submodules, whose development status vary a lot; add a disclaimer!

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add a disclaimer to the package's `__init__.py` file: A message will be printed upon the package's import.

## Questions
None.

## Status
- [ ] Ready to go