### PR TITLE
Check availability of theseus/mmligner executables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
     env:
       CI_OS: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest]
         python-version: [3.7, 3.8]
     env:
       CI_OS: ${{ matrix.os }}

--- a/opencadd/structure/superposition/engines/base.py
+++ b/opencadd/structure/superposition/engines/base.py
@@ -27,7 +27,11 @@ class BaseAligner:
             - ``metadata``: Contextual information provided by the method
 
         """
-        assert len(structures) == 2
+        self._safety_checks()
+        assert (
+            len(structures) == 2, 
+            "This method can only be used for two structures at the same time, for now"
+        )
         return self._calculate(structures, *args, **kwargs)
 
     def _calculate(self, structures, *args, **kwargs):

--- a/opencadd/structure/superposition/engines/base.py
+++ b/opencadd/structure/superposition/engines/base.py
@@ -32,6 +32,6 @@ class BaseAligner:
 
     def _calculate(self, structures, *args, **kwargs):
         raise NotImplementedError("Reimplement in your subclass")
-    
+
     def _safety_checks(self):
         raise NotImplementedError("Reimplement in your subclass")

--- a/opencadd/structure/superposition/engines/base.py
+++ b/opencadd/structure/superposition/engines/base.py
@@ -32,3 +32,6 @@ class BaseAligner:
 
     def _calculate(self, structures, *args, **kwargs):
         raise NotImplementedError("Reimplement in your subclass")
+    
+    def _safety_checks(self):
+        raise NotImplementedError("Reimplement in your subclass")

--- a/opencadd/structure/superposition/engines/base.py
+++ b/opencadd/structure/superposition/engines/base.py
@@ -29,8 +29,8 @@ class BaseAligner:
         """
         self._safety_checks()
         assert (
-            len(structures) == 2, 
-            "This method can only be used for two structures at the same time, for now"
+            len(structures) == 2,
+            "This method can only be used for two structures at the same time, for now",
         )
         return self._calculate(structures, *args, **kwargs)
 

--- a/opencadd/structure/superposition/engines/mda.py
+++ b/opencadd/structure/superposition/engines/mda.py
@@ -94,6 +94,13 @@ class MDAnalysisAligner(BaseAligner):
         self.superposition_weights = superposition_weights
         self.superposition_delta_mass_tolerance = superposition_delta_mass_tolerance
 
+    def _safety_checks(self):
+        """
+        Check for `mda` installation passes; added here only for consistency across the engines. 
+        """
+
+        pass
+
     def _calculate(self, structures, *args, **kwargs):
         """
 
@@ -109,6 +116,9 @@ class MDAnalysisAligner(BaseAligner):
             rmsd
             metadata
         """
+
+        self._safety_checks()
+
         if len(structures) > 2:
             raise NotImplementedError(
                 "This method can only be used for two structures at the same time, for now"

--- a/opencadd/structure/superposition/engines/mda.py
+++ b/opencadd/structure/superposition/engines/mda.py
@@ -96,7 +96,7 @@ class MDAnalysisAligner(BaseAligner):
 
     def _safety_checks(self):
         """
-        Check for `mda` installation passes; added here only for consistency across the engines. 
+        Check for `mda` installation passes; added here only for consistency across the engines.
         """
 
         pass

--- a/opencadd/structure/superposition/engines/mda.py
+++ b/opencadd/structure/superposition/engines/mda.py
@@ -117,12 +117,6 @@ class MDAnalysisAligner(BaseAligner):
             metadata
         """
 
-        self._safety_checks()
-
-        if len(structures) > 2:
-            raise NotImplementedError(
-                "This method can only be used for two structures at the same time, for now"
-            )
         ref_universe, mob_universe = structures
 
         # Get matching atoms

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -71,6 +71,7 @@ class MMLignerAligner(BaseAligner):
         theseus = find_executable("mmligner")
         if theseus is None:
             raise OSError("theseus cannot be located. Is it installed?")
+        # proceed normally
 
     def _calculate(self, structures, *args, **kwargs):
         """

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -68,9 +68,9 @@ class MMLignerAligner(BaseAligner):
             Raises error if executable `mmligner` cannot be found.
         """
 
-        theseus = find_executable("mmligner")
-        if theseus is None:
-            raise OSError("theseus cannot be located. Is it installed?")
+        mmligner = find_executable("mmligner")
+        if mmligner is None:
+            raise OSError("mmligner cannot be located. Is it installed?")
         # proceed normally
 
     def _calculate(self, structures, *args, **kwargs):

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -25,6 +25,7 @@ Bell Syst.Tech. J., 27, 379–423.
 import sys
 import subprocess
 import logging
+from distutils.spawn import find_executable
 
 import numpy as np
 import biotite.sequence.io.fasta as fasta
@@ -56,6 +57,20 @@ class MMLignerAligner(BaseAligner):
         _logger.warning(
             "Current MMLigner wrappers produces accurate RMSD values but slightly shifted structures!"
         )
+    
+    def _safety_checks(self):
+        """
+        Check if `mmligner` is installed (executable found?).
+
+        Raises
+        ------
+        OSError
+            Raises error if executable `mmligner` cannot be found.
+        """
+        
+        theseus = find_executable("mmligner")
+        if theseus is None:
+            raise OSError("theseus cannot be located. Is it installed?")
 
     def _calculate(self, structures, *args, **kwargs):
         """
@@ -83,6 +98,8 @@ class MMLignerAligner(BaseAligner):
                 - ``translation`` (np.array): array containing the translation
                 - ``quarternion`` (array-like): 4x4 quarternion matrix
         """
+
+        self._safety_checks()
 
         with enter_temp_directory() as (cwd, tmpdir):
             # Needed because of the need of a copy of the structures.

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -57,7 +57,7 @@ class MMLignerAligner(BaseAligner):
         _logger.warning(
             "Current MMLigner wrappers produces accurate RMSD values but slightly shifted structures!"
         )
-    
+
     def _safety_checks(self):
         """
         Check if `mmligner` is installed (executable found?).
@@ -67,7 +67,7 @@ class MMLignerAligner(BaseAligner):
         OSError
             Raises error if executable `mmligner` cannot be found.
         """
-        
+
         theseus = find_executable("mmligner")
         if theseus is None:
             raise OSError("theseus cannot be located. Is it installed?")

--- a/opencadd/structure/superposition/engines/mmligner.py
+++ b/opencadd/structure/superposition/engines/mmligner.py
@@ -100,8 +100,6 @@ class MMLignerAligner(BaseAligner):
                 - ``quarternion`` (array-like): 4x4 quarternion matrix
         """
 
-        self._safety_checks()
-
         with enter_temp_directory() as (cwd, tmpdir):
             # Needed because of the need of a copy of the structures.
             sys.setrecursionlimit(100000)

--- a/opencadd/structure/superposition/engines/theseus.py
+++ b/opencadd/structure/superposition/engines/theseus.py
@@ -122,8 +122,6 @@ class TheseusAligner(BaseAligner):
                     ``total_rounds``: total rounds
         """
 
-        self._safety_checks()
-
         with enter_temp_directory(remove=True) as (cwd, tmpdir):
             _logger.debug("All files are located in: %s", tmpdir)
 

--- a/opencadd/structure/superposition/engines/theseus.py
+++ b/opencadd/structure/superposition/engines/theseus.py
@@ -70,6 +70,7 @@ class TheseusAligner(BaseAligner):
         theseus = find_executable("theseus")
         if theseus is None:
             raise OSError("theseus cannot be located. Is it installed?")
+        # proceed normally
 
     def _calculate(self, structures, *args, **kwargs) -> dict:
         """

--- a/opencadd/structure/superposition/engines/theseus.py
+++ b/opencadd/structure/superposition/engines/theseus.py
@@ -56,7 +56,7 @@ class TheseusAligner(BaseAligner):
         self._alignment_file_biotite = "theseus_biotite.aln"
         self._alignment_executable = "muscle"
         self._theseus_transformation_file = "theseus_transf.txt"
-    
+
     def _safety_checks(self):
         """
         Check if `theseus` is installed (executable found?).
@@ -66,7 +66,7 @@ class TheseusAligner(BaseAligner):
         OSError
             Raises error if executable `theseus` cannot be found.
         """
-        
+
         theseus = find_executable("theseus")
         if theseus is None:
             raise OSError("theseus cannot be located. Is it installed?")

--- a/opencadd/structure/superposition/engines/theseus.py
+++ b/opencadd/structure/superposition/engines/theseus.py
@@ -21,6 +21,7 @@ References
 import os
 import subprocess
 import logging
+from distutils.spawn import find_executable
 
 import numpy as np
 
@@ -55,6 +56,20 @@ class TheseusAligner(BaseAligner):
         self._alignment_file_biotite = "theseus_biotite.aln"
         self._alignment_executable = "muscle"
         self._theseus_transformation_file = "theseus_transf.txt"
+    
+    def _safety_checks(self):
+        """
+        Check if `theseus` is installed (executable found?).
+
+        Raises
+        ------
+        OSError
+            Raises error if executable `theseus` cannot be found.
+        """
+        
+        theseus = find_executable("theseus")
+        if theseus is None:
+            raise OSError("theseus cannot be located. Is it installed?")
 
     def _calculate(self, structures, *args, **kwargs) -> dict:
         """
@@ -105,6 +120,8 @@ class TheseusAligner(BaseAligner):
                     ``n_structures``: number of structures
                     ``total_rounds``: total rounds
         """
+
+        self._safety_checks()
 
         with enter_temp_directory(remove=True) as (cwd, tmpdir):
             _logger.debug("All files are located in: %s", tmpdir)


### PR DESCRIPTION
## Description

We don't have Windows versions for `theseus` and `mmligner` as of now, thus currently no working Windows `opencadd` version.

Our workaround suggested by @jaimergp:
Add safety checks for these packages (incl. informative text for our users). With such a workaround we will be able to offer this package for Windows, too (without functionality for the bits that need `theseus` and `mmligner` though). 
If these packages will be available in the future, the respective bits in `opencadd` will work out-of-the-box, too.

More background details:
- Our package is labeled as noarch, which means we actually build it on linux (could be any other platform, but condaforge chose that one) and then hope it works in other OSs as well
- To be noarch our package needs to be pure python, no compiled extensions, and no per-platform dependencies
- We do need per-platform dependencies because some of those used in `opencadd` are not on windows
- We are ignoring that and adding checks in our code as a workaround
- When the dependencies become available, it will work magically in `opencadd`

## Todos
  - [x] Add `.safety_checks()` method to [`BaseAligner`](https://github.com/volkamerlab/opencadd/blob/master/opencadd/structure/superposition/engines/base.py) but implement code in respective classes, see below
  - [x] Add `_safety_checks()` implementation to [`TheseusAligner`](https://github.com/volkamerlab/opencadd/blob/88654c611163e9e3b57cd14800faa2f1ec99688a/opencadd/structure/superposition/engines/theseus.py) and [`MMLignerAligner`](https://github.com/volkamerlab/opencadd/blob/88654c611163e9e3b57cd14800faa2f1ec99688a/opencadd/structure/superposition/engines/mmligner.py):
     ```python
    from distutils.spawn import find_executable
    
    def align_with_theseus():
        theseus = find_executable("theseus")
        is theseus is None:
            raise Error("theseus cannot be located. Is it installed?")
        # proceed normally 
     ```
- [x] Add `_safety_checks()` to [`MDAnalysisAligner`]; only added for consistency across engines; simply passes (no executable check necessary since conda package available for all OS)
- [x] Call these methods in `BaseAligner.calculate` method

## Questions
None.

## Status
- [x] Ready to go