### PR TITLE
Remove io __init__ imports (to enable OpenCADD-KLIFS only deps)

### DIFF
--- a/docs/tutorials/io.ipynb
+++ b/docs/tutorials/io.ipynb
@@ -35,7 +35,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from opencadd.io import DataFrame, Rdkit, Biopython"
+    "from opencadd.io.dataframe import DataFrame\n",
+    "from opencadd.io.rdkit import Rdkit\n",
+    "from opencadd.io.biopython import Biopython\n"
    ]
   },
   {

--- a/opencadd/databases/klifs/local.py
+++ b/opencadd/databases/klifs/local.py
@@ -30,7 +30,8 @@ from .schema import (
 from .utils import PATH_DATA, metadata_to_filepath, filepath_to_metadata
 from .remote import KLIFS_CLIENT
 from .exceptions import KlifsPocketIncompleteError, KlifsPocketUnequalSequenceStructure
-from opencadd.io import DataFrame, Rdkit
+from opencadd.io.dataframe import DataFrame
+from opencadd.io.rdkit import Rdkit
 
 # Get the newest file version (* = YYYYMMDD)
 PATH_TO_KLIFS_IDS = sorted(PATH_DATA.glob("klifs_ids.*.csv.gz"), key=lambda x: x.suffixes[0])[-1]

--- a/opencadd/databases/klifs/remote.py
+++ b/opencadd/databases/klifs/remote.py
@@ -25,7 +25,8 @@ from .core import (
 )
 from .schema import FIELDS
 from .utils import metadata_to_filepath, silence_logging
-from opencadd.io import DataFrame, Rdkit
+from opencadd.io.dataframe import DataFrame
+from opencadd.io.rdkit import Rdkit
 
 _logger = logging.getLogger(__name__)
 

--- a/opencadd/io/__init__.py
+++ b/opencadd/io/__init__.py
@@ -1,7 +1,3 @@
 """
 opencadd.io module
 """
-
-from .biopython import Biopython
-from .dataframe import DataFrame
-from .rdkit import Rdkit

--- a/opencadd/structure/pocket/core.py
+++ b/opencadd/structure/pocket/core.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 
 import pandas as pd
-from opencadd.io import DataFrame
+from opencadd.io.dataframe import DataFrame
 
 from .base import PocketBase
 from .features.region import Region

--- a/opencadd/structure/pocket/viewer.py
+++ b/opencadd/structure/pocket/viewer.py
@@ -9,7 +9,7 @@ import logging
 from matplotlib import colors
 import nglview
 
-from opencadd.io import DataFrame
+from opencadd.io.dataframe import DataFrame
 
 _logger = logging.getLogger(__name__)
 

--- a/opencadd/tests/io/test_biopython.py
+++ b/opencadd/tests/io/test_biopython.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from Bio.PDB.Structure import Structure
 
-from opencadd.io import Biopython
+from opencadd.io.biopython import Biopython
 
 PATH_TEST_DATA = Path(__name__).parent / "opencadd" / "tests" / "data" / "io"
 

--- a/opencadd/tests/io/test_dataframes.py
+++ b/opencadd/tests/io/test_dataframes.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from opencadd.io import DataFrame
+from opencadd.io.dataframe import DataFrame
 from opencadd.io.schema import DATAFRAME_COLUMNS
 
 PATH_TEST_DATA = Path(__name__).parent / "opencadd" / "tests" / "data" / "io"

--- a/opencadd/tests/io/test_rdkit.py
+++ b/opencadd/tests/io/test_rdkit.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from rdkit import Chem
 
-from opencadd.io import Rdkit
+from opencadd.io.rdkit import Rdkit
 
 PATH_TEST_DATA = Path(__name__).parent / "opencadd" / "tests" / "data" / "io"
 


### PR DESCRIPTION
## Description
We'd like to enable user installations containing only dependencies for OpenCADD-KLIFS.
Currently, `opencadd.io`'s `__init__` file imports packages that are needed in different `opencadd` modules. Let's remove the imports and update all affected paths in the package and the docs.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Keep `opencadd.io.__init__` file but remove all imports
  - [x] Update all affected paths in the package and the docs

## Questions
None

## Status
- [x] Ready to go