### PR TITLE
Update docstring for KLIFS RMSD values

### DIFF
--- a/opencadd/databases/klifs/core.py
+++ b/opencadd/databases/klifs/core.py
@@ -684,9 +684,9 @@ class StructuresProvider(BaseProvider):
     structure.missing_atoms : int
         Number of missing atoms.
     structure.rmsd1 : float
-        RMSD between the structure and the reference template for the conserved pocket residues
+        RMSD between the structure and the reference template for the conserved pocket residues.
     structure.rmsd2 : float
-        RMSD between the structure and the reference template for the full pocket
+        RMSD between the structure and the reference template for the full pocket.
     structure.front : bool
         Orthosteric ligand occupies KLIFS front cleft.
         Available remotely only.

--- a/opencadd/databases/klifs/core.py
+++ b/opencadd/databases/klifs/core.py
@@ -684,9 +684,9 @@ class StructuresProvider(BaseProvider):
     structure.missing_atoms : int
         Number of missing atoms.
     structure.rmsd1 : float
-        RMSD between structure and reference structures based on full kinase domain.
+        RMSD between the structure and the reference template for the conserved pocket residues
     structure.rmsd2 : float
-        RMSD between structure and reference structures based on kinase pocket residues.
+        RMSD between the structure and the reference template for the full pocket
     structure.front : bool
         Orthosteric ligand occupies KLIFS front cleft.
         Available remotely only.


### PR DESCRIPTION
## Description
Correct docstring for `"structure.rmsd1"` and `"structure.rmsd2"` in `StructuresProvider` class.

## Todos
  - [x] Update docstring
    - RMSD1: RMSD between the structure and the reference template for the conserved pocket residues
    - RMSD2: RMSD between the structure and the reference template for the full pocket

## Questions
None

## Status
- [x] Ready to go