### PR TITLE
Docs: Extend installation instructions (add `conda-forge` channel note)

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -6,6 +6,8 @@ Installing
     We are assuming you have a working ``mamba`` installation in your computer. 
     If this is not the case, please refer to their `official documentation <https://mamba.readthedocs.io/en/latest/installation.html#mamba>`_. 
 
+    If you installed ``mamba`` into an existing ``conda`` installation, also make sure that the ``conda-forge`` channel is configured by running ``conda config --add channels conda-forge``.
+
 
 Install from the conda package
 ------------------------------

--- a/docs/installing_opencadd_klifs.rst
+++ b/docs/installing_opencadd_klifs.rst
@@ -8,6 +8,8 @@ In case you would like to install the dependencies for the OpenCADD-KLIFS module
     We are assuming you have a working ``mamba`` installation in your computer. 
     If this is not the case, please refer to their `official documentation <https://mamba.readthedocs.io/en/latest/installation.html#mamba>`_. 
 
+    If you installed ``mamba`` into an existing ``conda`` installation, also make sure that the ``conda-forge`` channel is configured by running ``conda config --add channels conda-forge``.
+
 
 Install from the conda package
 ------------------------------


### PR DESCRIPTION
## Description
Apply @mcs07's suggestion in issue https://github.com/volkamerlab/opencadd/issues/126:
Add note to installation for users who install `mamba` into existing `conda` installation (manual adding of `conda-forge` channel needed).

## Todos
  - [x] Add note to general OpenCADD and reduced OpenCADD-KLIFS installation instructions.

## Questions
None.

## Status
- [x] Ready to go