### PR TITLE
Docs: Set sphinx language from None to en

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = en
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = en
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
## Description
Docs have been failing for some time now:
https://github.com/volkamerlab/opencadd/runs/7493006534?check_suite_focus=true#step:5:269
I think this happens due to a warning - you now have to set a language in the sphinx config (instead of `None`):
https://github.com/volkamerlab/opencadd/runs/7493006534?check_suite_focus=true#step:5:13

## Todos
  - [x] Set sphinx language from None to en

## Status
- [x] Ready to go