### PR TITLE
Superposition: Cast universes w and w/o models to atom groups

### DIFF
--- a/opencadd/structure/superposition/api.py
+++ b/opencadd/structure/superposition/api.py
@@ -18,16 +18,16 @@ METHODS = {
 }
 
 
-def align(structures, user_select, method=TheseusAligner, **kwargs):
+def align(structures, user_select=False, method=TheseusAligner, **kwargs):
     """
     Main entry point for our project
 
     Parameters
     ----------
     structures : list of opencadd.core.Structure objects
-        First one will be the targer to which the rest are aligned.
-    user_seletct: list of MDAnalysis selection strings
-        Provided by user in the CLI-
+        First one will be the target to which the rest of the structures are aligned.
+    user_select: list of MDAnalysis selection strings
+        Provided by user in the CLI (default: False).
     method : BaseAligner-like
         Usually a subclass of BaseAligner. This will be passed ``**kwargs``. This class
         MUST define `.calculate()`.

--- a/opencadd/structure/superposition/api.py
+++ b/opencadd/structure/superposition/api.py
@@ -46,14 +46,14 @@ def align(structures, user_select=False, method=TheseusAligner, **kwargs):
 
     def _universe_to_atomgroup(universe):
         """
-        Universes can come with or without models. For downstream processing, cast all universes 
+        Universes can come with or without models. For downstream processing, cast all universes
         to AtomGroups.
 
         Parameters
         ----------
         universe : MDAnalysis.core.universe.Universe
             Input structure with or without models.
-        
+
         Returns
         -------
         MDAnalysis.core.groups.AtomGroup

--- a/opencadd/structure/superposition/api.py
+++ b/opencadd/structure/superposition/api.py
@@ -2,6 +2,9 @@
 Defines easy programmatic access for any entry point
 """
 
+from MDAnalysis.exceptions import NoDataError
+
+
 from .engines.theseus import TheseusAligner
 from .engines.mmligner import MMLignerAligner
 from .engines.mda import MDAnalysisAligner
@@ -41,6 +44,27 @@ def align(structures, user_select, method=TheseusAligner, **kwargs):
     reference, *mobiles = structures
     results = []
 
+    def _universe_to_atomgroup(universe):
+        """
+        Universes can come with or without models. For downstream processing, cast all universes 
+        to AtomGroups.
+
+        Parameters
+        ----------
+        universe : MDAnalysis.core.universe.Universe
+            Input structure with or without models.
+        
+        Returns
+        -------
+        MDAnalysis.core.groups.AtomGroup
+            Structure as AtomGroup (keep only first model if multiple models available).
+        """
+        try:
+            atom_group = universe.models[0]
+        except NoDataError:
+            atom_group = universe.atoms
+        return atom_group
+
     # only take the first models of the pdb files, this ensures that mda and theseus are working consistently
     # comparing all models could provide better results, but would be very inefficient
     # (e.g. 25 models would mean 25 times the computing time)
@@ -48,10 +72,10 @@ def align(structures, user_select, method=TheseusAligner, **kwargs):
         # selection always returns an AtomGroup. Alternative, which is not recommended,
         # because the aligners can handle AtomGroups aswell:
         # Structure.from_atomgroup(reference.models[0].select_atoms(f"{user_select}").residues.atoms)
-        reference = reference.models[0]
+        reference = _universe_to_atomgroup(reference)
         reference_selection = reference.select_atoms(f"{user_select[0]}")
         for mobile in mobiles:
-            mobile = mobile.models[0]
+            mobile = _universe_to_atomgroup(mobile)
             mobile_selection = mobile.select_atoms(f"{user_select[1]}")
             result = aligner.calculate(
                 structures=[reference, mobile], selections=[reference_selection, mobile_selection]
@@ -64,9 +88,9 @@ def align(structures, user_select, method=TheseusAligner, **kwargs):
             results.append(result)
 
     else:
-        reference = reference.models[0]
+        reference = _universe_to_atomgroup(reference)
         for mobile in mobiles:
-            mobile = mobile.models[0]
+            mobile = _universe_to_atomgroup(mobile)
             result = aligner.calculate(structures=[reference, mobile], selections=[])
             # size of whole structures
             reference_size = len(reference.residues)


### PR DESCRIPTION
## Description
Universes can come with or without models. Currently, we only consider universes with models in our `superposition` module: the first model is selected for the alignment. After this selection, the object type changes from an MDA `Universe` to `AtomGroup`.

Example:
```python
# With models
structures = [Structure.from_pdbid("4y72"), Structure.from_pdbid("1xqz"), Structure.from_pdbid("1m17")]
align(structures, user_select=False, method=METHODS["mda"]);

# Without models (casting an MDA NoDataError)
f1, f2, f3 = ...  # Path to PDB files*
structures = [Structure.from_string(f1), Structure.from_string(f2), Structure.from_string(f3)]
align(structures, user_select=False, method=METHODS["mda"]);
```

*Download PBD files (terminal):
```bash
for pdb in 4y72 1xqz 1m17; do wget https://www.rcsb.org/structure/$pdb -o $pdb.pdb; done
```

## Solution
Cast all universes (regardless of whether they contain models or not) to AtomGroup objects.

## Todos
  - [x] Add `_universe_to_atomgroup` function
  - [x] Apply function to reference and all mobile structures before the alignment
  - [x] [Off-topic] Make `opencadd.structure.superposition.api.align` parameter `user_select` optional (default is `False`); this will allow back-compatibility with earlier version when `user_select` was not a parameter, yet.

## Status
- [x] Ready to go