### PR TITLE
Update GHA CI configs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       PACKAGE: "opencadd"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Additional info about the build
         shell: bash
@@ -36,17 +36,14 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/conda-incubator/setup-miniconda
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: test
           environment-file: devtools/conda-envs/test_env.yaml
           channels: conda-forge,defaults,bioconda
-          activate-environment: test
-          auto-update-conda: true
-          auto-activate-base: false
-          show-channel-urls: true
-          mamba-version: "*"
 
       # TODO: Remove this step when patched theseus makes it to CF
       - name: Build patched mmligner

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,23 +79,20 @@ jobs:
     env:
       CI_OS: ubuntu-latest
       PACKAGE: "opencadd"
-      PYVER: "3.7"
+      PYVER: "3.8"
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # More info on options: https://github.com/conda-incubator/setup-miniconda
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.8"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: test
           environment-file: devtools/conda-envs/test_env.yaml
           channels: conda-forge,defaults,bioconda
-          activate-environment: test
-          auto-update-conda: true
-          auto-activate-base: false
-          show-channel-urls: true
-          mamba-version: "*"
 
       - name: Install linter and formatter
         shell: bash -l {0}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,23 +17,20 @@ jobs:
     env:
       CI_OS: ubuntu-latest
       PACKAGE: "opencadd"
-      PYVER: "3.7"
+      PYVER: "3.8"
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # More info on options: https://github.com/conda-incubator/setup-miniconda
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.8"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: test
           environment-file: devtools/conda-envs/test_env.yaml
           channels: conda-forge,defaults,bioconda
-          activate-environment: test
-          auto-update-conda: true
-          auto-activate-base: false
-          show-channel-urls: true
-          mamba-version: "*"
 
       - name: Install package
         shell: bash -l {0}


### PR DESCRIPTION
## Description
Update GHA CI configs (prompted by conda fails).

## Todos

- [x] CI: Update actions/checkout from v2 to v3
- [x] CI: Use mambaforge instead of mamba as resolver

## Status
- [x] Ready to go